### PR TITLE
NP-46868-security-headers

### DIFF
--- a/cristin-person/src/main/java/no/unit/nva/cristin/person/update/PersonPatchValidator.java
+++ b/cristin-person/src/main/java/no/unit/nva/cristin/person/update/PersonPatchValidator.java
@@ -29,6 +29,7 @@ import no.unit.nva.model.TypedLabel;
 import no.unit.nva.utils.UriUtils;
 import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.core.JacocoGenerated;
+import nva.commons.core.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -171,6 +172,7 @@ public final class PersonPatchValidator {
                 Optional.of(personNvi)
                     .map(PersonNvi::verifiedBy)
                     .map(PersonSummary::id)
+                    .filter(uri -> StringUtils.isNotBlank(uri.toString()))
                     .map(UriUtils::extractLastPathElement)
                     .filter(Utils::isPositiveInteger)
                     .orElseThrow(() -> invalidIdentifier(MUST_HAVE_A_VALID_PERSON_IDENTIFIER));

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 junit = { strictly = '5.10.2' }
-nva-commons = {strictly = '1.38.3'}
-jackson = { strictly = '2.15.2' } # 2.16.1 Which nva-commons uses breaks some tests
+nva-commons = { strictly = '1.39.3' }
+jackson = { require = '2.16.1' }
 mockito = { strictly = '5.11.0' }
 hamcrest = { strictly = '2.2' }
 zalando = { strictly = '0.27.1' }


### PR DESCRIPTION
nva-commons = { strictly = '1.39.3' } kommer med oppdatert ApiGatewayHandler som setter to security headers.