### PR TITLE
Noissue remove redundant depth param

### DIFF
--- a/cristin-organization/src/main/java/no/unit/nva/cristin/organization/common/QueryParamConverter.java
+++ b/cristin-organization/src/main/java/no/unit/nva/cristin/organization/common/QueryParamConverter.java
@@ -1,11 +1,8 @@
 package no.unit.nva.cristin.organization.common;
 
-import static java.util.Objects.isNull;
 import static no.unit.nva.cristin.model.Constants.CRISTIN_PER_PAGE_PARAM;
 import static no.unit.nva.cristin.model.Constants.CRISTIN_QUERY_NAME_PARAM;
 import static no.unit.nva.cristin.model.Constants.SORT;
-import static no.unit.nva.cristin.model.Constants.TOP;
-import static no.unit.nva.cristin.model.JsonPropertyNames.DEPTH;
 import static no.unit.nva.cristin.model.JsonPropertyNames.NUMBER_OF_RESULTS;
 import static no.unit.nva.cristin.model.JsonPropertyNames.PAGE;
 import static no.unit.nva.cristin.model.JsonPropertyNames.QUERY;
@@ -14,16 +11,11 @@ import java.util.concurrent.ConcurrentHashMap;
 
 public class QueryParamConverter {
 
-    public static final String CRISTIN_LEVELS_PARAM = "levels";
-    public static final String FIRST_LEVEL = "1";
-    public static final String ALL_SUB_LEVELS = "32";
-
     /**
      * Transforms request query params to cristin format for query params.
      */
     public static Map<String, String> translateToCristinApi(Map<String, String> requestQueryParams) {
         var translatedParams = new ConcurrentHashMap<>(Map.of(
-            CRISTIN_LEVELS_PARAM, toCristinLevel(requestQueryParams.get(DEPTH)),
             CRISTIN_QUERY_NAME_PARAM, requestQueryParams.get(QUERY),
             PAGE, requestQueryParams.get(PAGE),
             CRISTIN_PER_PAGE_PARAM, requestQueryParams.get(NUMBER_OF_RESULTS)));
@@ -33,10 +25,6 @@ public class QueryParamConverter {
         }
 
         return translatedParams;
-    }
-
-    private static String toCristinLevel(String depth) {
-        return TOP.equals(depth) || isNull(depth) ? FIRST_LEVEL : ALL_SUB_LEVELS;
     }
 
 }

--- a/cristin-organization/src/main/java/no/unit/nva/cristin/organization/common/client/v20230526/OrganizationEnricher.java
+++ b/cristin-organization/src/main/java/no/unit/nva/cristin/organization/common/client/v20230526/OrganizationEnricher.java
@@ -1,6 +1,5 @@
 package no.unit.nva.cristin.organization.common.client.v20230526;
 
-import static no.unit.nva.cristin.model.JsonPropertyNames.DEPTH;
 import static no.unit.nva.cristin.model.JsonPropertyNames.IDENTIFIER;
 import static nva.commons.core.attempt.Try.attempt;
 import java.util.ArrayList;
@@ -25,7 +24,6 @@ public class OrganizationEnricher {
         "Organization from search result could not be found in upstream: {}";
 
     private final List<Organization> inputOrganizations;
-    private final Map<String, String> queryParams;
     private final FetchApiClient<Map<String, String>, Organization> fetchClient;
     private final List<Organization> enrichedOrganizations;
 
@@ -34,14 +32,11 @@ public class OrganizationEnricher {
      * list.
      *
      * @param inputOrganizations The input list of organizations
-     * @param queryParams        The query params used in the original query
      * @param fetchClient        The client used for fetching the enriched data
     **/
     public OrganizationEnricher(List<Organization> inputOrganizations,
-                                Map<String, String> queryParams,
                                 FetchApiClient<Map<String, String>, Organization> fetchClient) {
         this.inputOrganizations = inputOrganizations;
-        this.queryParams = queryParams;
         this.fetchClient = fetchClient;
         enrichedOrganizations = new ArrayList<>();
     }
@@ -71,7 +66,6 @@ public class OrganizationEnricher {
 
     private Map<String, String> extractParams(String identifier) {
         var enrichParams = new ConcurrentHashMap<String, String>();
-        enrichParams.put(DEPTH, queryParams.get(DEPTH));
         enrichParams.put(IDENTIFIER, identifier);
 
         return enrichParams;

--- a/cristin-organization/src/main/java/no/unit/nva/cristin/organization/common/client/v20230526/QueryCristinOrgClient20230526.java
+++ b/cristin-organization/src/main/java/no/unit/nva/cristin/organization/common/client/v20230526/QueryCristinOrgClient20230526.java
@@ -60,7 +60,7 @@ public class QueryCristinOrgClient20230526 extends ApiClient
         var response = queryUpstream(queryUri);
         var organizations = getOrganizations(response);
         if (wantsFullTree(params)) {
-            var organizationEnricher = new OrganizationEnricher(organizations, params, fetchClient);
+            var organizationEnricher = new OrganizationEnricher(organizations, fetchClient);
             organizations = organizationEnricher.enrich().getResult();
         }
         var totalProcessingTime = calculateProcessingTime(start, System.currentTimeMillis());

--- a/cristin-organization/src/main/java/no/unit/nva/cristin/organization/query/QueryCristinOrganizationHandler.java
+++ b/cristin-organization/src/main/java/no/unit/nva/cristin/organization/query/QueryCristinOrganizationHandler.java
@@ -27,7 +27,6 @@ import static no.unit.nva.cristin.model.JsonPropertyNames.DEPTH;
 import static no.unit.nva.cristin.model.JsonPropertyNames.NUMBER_OF_RESULTS;
 import static no.unit.nva.cristin.model.JsonPropertyNames.PAGE;
 import static no.unit.nva.cristin.model.JsonPropertyNames.QUERY;
-import static no.unit.nva.cristin.organization.common.HandlerUtil.getValidDepth;
 import static no.unit.nva.utils.VersioningUtils.ACCEPT_HEADER_KEY_NAME;
 import static no.unit.nva.utils.VersioningUtils.extractVersionFromRequestInfo;
 
@@ -84,7 +83,6 @@ public class QueryCristinOrganizationHandler extends CristinQueryHandler<Void, S
         var requestQueryParams = new ConcurrentHashMap<String, String>();
 
         requestQueryParams.put(QUERY, getValidQuery(requestInfo));
-        requestQueryParams.put(DEPTH, getValidDepth(requestInfo));
         requestQueryParams.put(PAGE, getValidPage(requestInfo));
         requestQueryParams.put(NUMBER_OF_RESULTS, getValidNumberOfResults(requestInfo));
         getSort(requestInfo).ifPresent(sort -> requestQueryParams.put(SORT, sort));

--- a/cristin-organization/src/test/java/no/unit/nva/cristin/organization/query/QueryCristinOrganizationHandlerTest.java
+++ b/cristin-organization/src/test/java/no/unit/nva/cristin/organization/query/QueryCristinOrganizationHandlerTest.java
@@ -48,7 +48,6 @@ import static java.net.HttpURLConnection.HTTP_BAD_GATEWAY;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
-import static no.unit.nva.cristin.common.ErrorMessages.ERROR_MESSAGE_DEPTH_INVALID;
 import static no.unit.nva.client.ClientProvider.VERSION_2023_05_26;
 import static no.unit.nva.client.ClientProvider.VERSION_ONE;
 import static no.unit.nva.cristin.model.Constants.FULL;
@@ -163,16 +162,6 @@ class QueryCristinOrganizationHandlerTest {
         assertEquals(HttpURLConnection.HTTP_OK, gatewayResponse.getStatusCode());
         assertEquals(2, actual.getHits().size());
         assertEquals(JSON_UTF_8.toString(), gatewayResponse.getHeaders().get(HttpHeaders.CONTENT_TYPE));
-    }
-
-    @Test
-    void shouldReturnBadRequestOnIllegalDepth() throws IOException {
-        var inputStream = generateHandlerRequestWithIllegalDepthParameter();
-        queryCristinOrganizationHandler.handleRequest(inputStream, output, context);
-        var gatewayResponse = GatewayResponse.fromOutputStream(output,Problem.class);
-        var actualDetail = getProblemDetail(gatewayResponse);
-        assertEquals(HTTP_BAD_REQUEST, gatewayResponse.getStatusCode());
-        assertThat(actualDetail, containsString(ERROR_MESSAGE_DEPTH_INVALID));
     }
 
     @ParameterizedTest(name = "Requesting version {0} should call version one {1} times and version two {2} times")
@@ -452,13 +441,6 @@ class QueryCristinOrganizationHandlerTest {
         return new HandlerRequestBuilder<InputStream>(restApiMapper)
                 .withHeaders(Map.of(CONTENT_TYPE, APPLICATION_JSON_LD.type()))
                 .withQueryParameters(Map.of(QUERY, "strangeQueryWithoutHits"))
-                .build();
-    }
-
-    private InputStream generateHandlerRequestWithIllegalDepthParameter() throws JsonProcessingException {
-        return new HandlerRequestBuilder<InputStream>(restApiMapper)
-                .withHeaders(Map.of(CONTENT_TYPE, APPLICATION_JSON_LD.type()))
-                .withQueryParameters(Map.of(QUERY, "Fysikk", DEPTH, "feil"))
                 .build();
     }
 

--- a/cristin-person/src/main/java/no/unit/nva/cristin/person/client/CristinPersonQuery.java
+++ b/cristin-person/src/main/java/no/unit/nva/cristin/person/client/CristinPersonQuery.java
@@ -1,6 +1,7 @@
 package no.unit.nva.cristin.person.client;
 
 import static no.unit.nva.cristin.model.Constants.CRISTIN_API_URL;
+import static no.unit.nva.cristin.model.Constants.PARENT_UNIT_ID;
 import static no.unit.nva.cristin.model.Constants.PERSON_PATH;
 import static no.unit.nva.cristin.model.Constants.SORT;
 import static no.unit.nva.cristin.person.model.nva.JsonPropertyNames.VERIFIED;
@@ -15,7 +16,6 @@ import nva.commons.core.paths.UriWrapper;
 public class CristinPersonQuery {
 
     public static final String NIN_PARAM_KEY = "national_id";
-    public static final String PARENT_UNIT_ID = "parent_unit_id";
     private static final String CRISTIN_QUERY_PARAMETER_NAME_KEY = "name";
     private static final String CRISTIN_QUERY_PARAMETER_ORGANIZATION_KEY = "institution";
     private static final String CRISTIN_QUERY_PARAMETER_PAGE_KEY = "page";

--- a/cristin-person/src/main/java/no/unit/nva/cristin/person/model/cristin/CristinPerson.java
+++ b/cristin-person/src/main/java/no/unit/nva/cristin/person/model/cristin/CristinPerson.java
@@ -40,7 +40,7 @@ import static no.unit.nva.cristin.model.Constants.PERSON_PATH_NVA;
 import static no.unit.nva.cristin.person.model.nva.JsonPropertyNames.NATIONAL_IDENTITY_NUMBER;
 
 @SuppressWarnings({"unused", "PMD.GodClass", "PMD.TooManyFields", "PMD.ExcessivePublicCount",
-        "PMD.CouplingBetweenObjects"})
+    "PMD.CouplingBetweenObjects"})
 @JacocoGenerated
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class CristinPerson implements JsonSerializable {

--- a/docs/cristin-proxy-swagger.yaml
+++ b/docs/cristin-proxy-swagger.yaml
@@ -588,17 +588,6 @@ paths:
           example: 'Universitetet i'
           style: form
           explode: false
-        - name: depth
-          in: query
-          description: Depth of sub-organizations included in response
-          required: false
-          schema:
-            type: string
-            enum:
-              - full
-              - top
-          style: form
-          explode: false
         - name: page
           in: query
           description: Current page requested


### PR DESCRIPTION
We do not need depth param for organisation query endpoint, and neither for its enricher. It will still fetch the whole tree if we want using fullTree=true. I do not think it had any uses anyway being there or not did not make any difference. at least not for this particular endpoint