### PR TITLE
np-47669: use our own format for sort params incase we replace cristi…

### DIFF
--- a/cristin-organization/src/main/java/no/unit/nva/cristin/organization/common/QueryParamConverter.java
+++ b/cristin-organization/src/main/java/no/unit/nva/cristin/organization/common/QueryParamConverter.java
@@ -29,7 +29,9 @@ public class QueryParamConverter {
             CRISTIN_PER_PAGE_PARAM, requestQueryParams.get(NUMBER_OF_RESULTS)));
 
         if (requestQueryParams.containsKey(SORT)) {
-            translatedParams.put(SORT, requestQueryParams.get(SORT));
+            var sort = requestQueryParams.get(SORT);
+            var sortConverted = convertSortValues(sort);
+            translatedParams.put(SORT, sortConverted);
         }
 
         return translatedParams;
@@ -37,6 +39,12 @@ public class QueryParamConverter {
 
     private static String toCristinLevel(String depth) {
         return TOP.equals(depth) || isNull(depth) ? FIRST_LEVEL : ALL_SUB_LEVELS;
+    }
+
+    private static String convertSortValues(String input) {
+        return input.replace("nameNb", "name_nb")
+                   .replace("nameEn", "name_en")
+                   .replace("nameNn", "name_nn");
     }
 
 }

--- a/cristin-organization/src/test/java/no/unit/nva/cristin/organization/organization.feature
+++ b/cristin-organization/src/test/java/no/unit/nva/cristin/organization/organization.feature
@@ -138,3 +138,15 @@ Feature: API tests for Cristin Organization retrieve and search
     Then status 200
     And match response.hits == '#array'
     And match response.hits == '#[1]'
+
+  Scenario: GET organization sorting on name in english returns results
+    Given path '/organization'
+    And param query = testOrganizationNameSearchTerm
+    And param results = '2'
+    And param page = '4'
+    And param sort = 'nameEn'
+    When method GET
+    Then status 200
+    And match response.hits == '#array'
+    And match response.size == '#number'
+    And match response.hits == '#[2]' // hits array length == 0

--- a/cristin-organization/src/test/java/no/unit/nva/cristin/organization/query/QueryCristinOrganizationHandlerTest.java
+++ b/cristin-organization/src/test/java/no/unit/nva/cristin/organization/query/QueryCristinOrganizationHandlerTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.zalando.problem.Problem;
 
@@ -44,6 +45,7 @@ import java.util.Map;
 
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static com.google.common.net.MediaType.JSON_UTF_8;
+import static java.lang.String.format;
 import static java.net.HttpURLConnection.HTTP_BAD_GATEWAY;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
@@ -213,7 +215,7 @@ class QueryCristinOrganizationHandlerTest {
 
         queryCristinOrganizationHandler = new QueryCristinOrganizationHandler(clientProvider, new Environment());
         var input =
-            generateValidHandlerRequestWithVersionParam(String.format(ACCEPT_HEADER_EXAMPLE, VERSION_2023_05_26));
+            generateValidHandlerRequestWithVersionParam(format(ACCEPT_HEADER_EXAMPLE, VERSION_2023_05_26));
         queryCristinOrganizationHandler.handleRequest(input, output, context);
 
         var gatewayResponse = GatewayResponse.fromOutputStream(output,
@@ -231,32 +233,25 @@ class QueryCristinOrganizationHandlerTest {
         assertThat(readHitsAsTree(actualHits), equalTo(readHitsAsTree(expectedHits)));
     }
 
-    @Test
-    void shouldHaveCorrectCristinUriWithParamsOnVersionOne() throws Exception {
+    @ParameterizedTest(name = "Version {0} has correct upstream uri")
+    @ValueSource(strings = {VERSION_ONE, VERSION_2023_05_26})
+    void shouldHaveCorrectCristinUriWithParamsDifferentVersions(String apiVersion) throws Exception {
         queryCristinOrganizationHandler = new QueryCristinOrganizationHandler(clientProvider, new Environment());
-        var input = generateHandlerRequestWithAdditionalQueryParameters(String.format(ACCEPT_HEADER_EXAMPLE,
-                                                                                      VERSION_ONE));
+        var input = generateHandlerRequestWithAdditionalQueryParameters(format(ACCEPT_HEADER_EXAMPLE,
+                                                                               apiVersion));
         queryCristinOrganizationHandler.handleRequest(input, output, context);
 
         var captor = ArgumentCaptor.forClass(URI.class);
-        var gatewayResponse = GatewayResponse.fromOutputStream(output, SearchResponse.class);
+        final var gatewayResponse = GatewayResponse.fromOutputStream(output, SearchResponse.class);
 
-        verify(cristinApiClientVersionOne).sendRequestMultipleTimes(captor.capture());
-        assertThat(captor.getValue().getQuery(), containsString("sort=country desc"));
-        assertThat(gatewayResponse.getStatusCode(), equalTo(HTTP_OK));
-    }
+        if (VERSION_2023_05_26.equals(apiVersion)) {
+            verify(queryCristinOrgClient20230526).fetchQueryResults(captor.capture());
+        } else {
+            verify(cristinApiClientVersionOne).sendRequestMultipleTimes(captor.capture());
+        }
 
-    @Test
-    void shouldHaveCorrectCristinUriWithParamsOnVersionTwo() throws Exception {
-        queryCristinOrganizationHandler = new QueryCristinOrganizationHandler(clientProvider, new Environment());
-        var input = generateHandlerRequestWithAdditionalQueryParameters(String.format(ACCEPT_HEADER_EXAMPLE,
-                                                                                      VERSION_2023_05_26));
-        queryCristinOrganizationHandler.handleRequest(input, output, context);
-
-        var captor = ArgumentCaptor.forClass(URI.class);
-        var gatewayResponse = GatewayResponse.fromOutputStream(output, SearchResponse.class);
-
-        verify(queryCristinOrgClient20230526).fetchQueryResults(captor.capture());
+        assertThat(captor.getValue().toString(), containsString("https://api.cristin-test.uio.no/v2/units?"));
+        assertThat(captor.getValue().getQuery(), containsString("name=strangeQueryWithoutHits"));
         assertThat(captor.getValue().getQuery(), containsString("sort=country desc"));
         assertThat(gatewayResponse.getStatusCode(), equalTo(HTTP_OK));
     }
@@ -362,8 +357,8 @@ class QueryCristinOrganizationHandlerTest {
             .when(queryCristinOrgClient20230526).fetchQueryResults(any());
 
         queryCristinOrganizationHandler = new QueryCristinOrganizationHandler(clientProvider, new Environment());
-        var input = generateValidHandlerRequestWithVersionParam(String.format(ACCEPT_HEADER_EXAMPLE,
-                                                                              VERSION_2023_05_26));
+        var input = generateValidHandlerRequestWithVersionParam(format(ACCEPT_HEADER_EXAMPLE,
+                                                                       VERSION_2023_05_26));
         queryCristinOrganizationHandler.handleRequest(input, output, context);
 
         var gatewayResponse = GatewayResponse.fromOutputStream(output, SearchResponse.class);
@@ -408,6 +403,35 @@ class QueryCristinOrganizationHandlerTest {
         assertThat(gatewayResponse.getStatusCode(), equalTo(HTTP_OK));
     }
 
+    @ParameterizedTest(name = "Sort param {1} gets converted to {2} on api version {0}")
+    @MethodSource("sortAndVersionArgumentProvider")
+    void shouldConvertSortParamBetweenNvaFormatAndCristinFormat(String apiVersion,
+                                                                String nvaSort,
+                                                                String cristinSort)
+        throws Exception {
+
+        queryCristinOrganizationHandler = new QueryCristinOrganizationHandler(clientProvider, new Environment());
+        var input = generateHandlerRequestWithSortParameters(
+            format(ACCEPT_HEADER_EXAMPLE, apiVersion),
+            nvaSort
+        );
+        queryCristinOrganizationHandler.handleRequest(input, output, context);
+
+        var captor = ArgumentCaptor.forClass(URI.class);
+        var gatewayResponse = GatewayResponse.fromOutputStream(output, SearchResponse.class);
+
+        if (VERSION_2023_05_26.equals(apiVersion)) {
+            verify(queryCristinOrgClient20230526).fetchQueryResults(captor.capture());
+        } else {
+            verify(cristinApiClientVersionOne).sendRequestMultipleTimes(captor.capture());
+        }
+
+        var sortTemplate = "sort=%s";
+
+        assertThat(captor.getValue().getQuery(), containsString(format(sortTemplate, cristinSort)));
+        assertThat(gatewayResponse.getStatusCode(), equalTo(HTTP_OK));
+    }
+
     private List<Organization> convertHitsToProperFormat(SearchResponse<?> searchResponse) {
         return OBJECT_MAPPER.convertValue(searchResponse.getHits(), new TypeReference<>() {});
     }
@@ -429,8 +453,8 @@ class QueryCristinOrganizationHandlerTest {
 
     private static Stream<Arguments> versionArgumentProvider() {
         return Stream.of(
-            Arguments.of(String.format(ACCEPT_HEADER_EXAMPLE, VERSION_ONE), 1, 0),
-            Arguments.of(String.format(ACCEPT_HEADER_EXAMPLE, VERSION_2023_05_26), 0, 1)
+            Arguments.of(format(ACCEPT_HEADER_EXAMPLE, VERSION_ONE), 1, 0),
+            Arguments.of(format(ACCEPT_HEADER_EXAMPLE, VERSION_2023_05_26), 0, 1)
         );
     }
 
@@ -503,7 +527,7 @@ class QueryCristinOrganizationHandlerTest {
         return new HandlerRequestBuilder<InputStream>(restApiMapper)
                    .withHeaders(Map.of(CONTENT_TYPE, APPLICATION_JSON_LD.type(),
                                        ACCEPT_HEADER_KEY_NAME,
-                                       String.format(ACCEPT_HEADER_EXAMPLE, VERSION_2023_05_26)))
+                                       format(ACCEPT_HEADER_EXAMPLE, VERSION_2023_05_26)))
                    .withQueryParameters(Map.of(QUERY, MEDICAL_BIOCHEMISTRY,
                                                DEPTH, FULL,
                                                FULL_TREE, Boolean.TRUE.toString()))
@@ -540,6 +564,58 @@ class QueryCristinOrganizationHandlerTest {
             Arguments.of("Hogeschool IPABO Amsterdam/Alkmaar"),
             Arguments.of("University of Technology, Sydney - Branch: St. Leonards Campus)")
         );
+    }
+
+    private static Stream<Arguments> sortAndVersionArgumentProvider() {
+        return Stream.of(
+            Arguments.of(VERSION_ONE,
+                         "nameEn",
+                         "name_en"),
+            Arguments.of(VERSION_ONE,
+                         "nameEn asc",
+                         "name_en asc"),
+            Arguments.of(VERSION_ONE,
+                         "nameEn desc",
+                         "name_en desc"),
+            Arguments.of(VERSION_2023_05_26,
+                         "nameEn",
+                         "name_en"),
+            Arguments.of(VERSION_2023_05_26,
+                         "nameEn asc",
+                         "name_en asc"),
+            Arguments.of(VERSION_2023_05_26,
+                         "nameEn desc",
+                         "name_en desc"),
+            Arguments.of(VERSION_ONE,
+                         "nameNb",
+                         "name_nb"),
+            Arguments.of(VERSION_ONE,
+                         "nameNb asc",
+                         "name_nb asc"),
+            Arguments.of(VERSION_ONE,
+                         "nameNb desc",
+                         "name_nb desc"),
+            Arguments.of(VERSION_2023_05_26,
+                         "nameNb",
+                         "name_nb"),
+            Arguments.of(VERSION_2023_05_26,
+                         "nameNb asc",
+                         "name_nb asc"),
+            Arguments.of(VERSION_2023_05_26,
+                         "nameNb desc",
+                         "name_nb desc")
+        );
+    }
+
+    private InputStream generateHandlerRequestWithSortParameters(String versionParam, String nvaSortParam)
+        throws JsonProcessingException {
+
+        return new HandlerRequestBuilder<InputStream>(restApiMapper)
+                   .withHeaders(Map.of(CONTENT_TYPE, APPLICATION_JSON_LD.type(),
+                                       ACCEPT_HEADER_KEY_NAME, versionParam))
+                   .withQueryParameters(Map.of(QUERY, "strangeQueryWithoutHits",
+                                               SORT, nvaSortParam))
+                   .build();
     }
 
 }

--- a/docs/cristin-proxy-swagger.yaml
+++ b/docs/cristin-proxy-swagger.yaml
@@ -635,15 +635,15 @@ paths:
               - country
               - country asc
               - country desc
-              - name_en
-              - name_en asc
-              - name_en desc
-              - name_nb
-              - name_nb asc
-              - name_nb desc
-              - name_nn
-              - name_nn asc
-              - name_nn desc
+              - nameEn
+              - nameEn asc
+              - nameEn desc
+              - nameNb
+              - nameNb asc
+              - nameNb desc
+              - nameNn
+              - nameNn asc
+              - nameNn desc
           style: form
           explode: false
         - name: fullTree


### PR DESCRIPTION
Use our own format for sort params to make it more upstream agnostic. this way we can change upstream without changing our params