### PR TITLE
Migrate person response to valid json-ld

### DIFF
--- a/cristin-commons/src/main/java/no/unit/nva/cristin/model/Constants.java
+++ b/cristin-commons/src/main/java/no/unit/nva/cristin/model/Constants.java
@@ -53,7 +53,7 @@ public class Constants {
     public static final String PATTERN_IS_URL =
         "(http(s):\\/\\/.)[-a-zA-Z0-9@:%._\\+~#=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%_\\+.~#?&//=]*)";
     public static final String PERSONS_PATH = "persons";
-    public static final String PERSON_CONTEXT = "https://example.org/person-context.json";
+    public static final String PERSON_CONTEXT = "https://bibsysdev.github.io/src/person-context.json";
     public static final String PERSON_ID = "id";
     public static final String PERSON_PATH = "persons";
     public static final String PERSON_PATH_NVA = "person";

--- a/cristin-commons/src/main/java/no/unit/nva/cristin/model/JsonPropertyNames.java
+++ b/cristin-commons/src/main/java/no/unit/nva/cristin/model/JsonPropertyNames.java
@@ -3,13 +3,13 @@ package no.unit.nva.cristin.model;
 import nva.commons.core.JacocoGenerated;
 
 @JacocoGenerated
-public class JsonPropertyNames {
-
+public final class JsonPropertyNames {
 
     public static final String ACADEMIC_SUMMARY = "academicSummary";
     public static final String ACRONYM = "acronym";
     public static final String AFFILIATION = "affiliation";
     public static final String ALTERNATIVE_TITLES = "alternativeTitles";
+    public static final String AWARD_FOR = "awardFor";
     public static final String BIOBANK_ID = "biobank";
     public static final String CONTACT_INFO = "contactInfo";
     public static final String CONTEXT = "@context";
@@ -77,4 +77,8 @@ public class JsonPropertyNames {
     public static final String YEAR = "year";
     public static final String DISTRIBUTION = "distribution";
     public static final String CRISTIN_PERSON_ID = "cristin_person_id";
+
+    private JsonPropertyNames() {
+        // NO-OP
+    }
 }

--- a/cristin-person/src/main/java/no/unit/nva/cristin/person/model/cristin/CristinPerson.java
+++ b/cristin-person/src/main/java/no/unit/nva/cristin/person/model/cristin/CristinPerson.java
@@ -40,7 +40,7 @@ import static no.unit.nva.cristin.model.Constants.PERSON_PATH_NVA;
 import static no.unit.nva.cristin.person.model.nva.JsonPropertyNames.NATIONAL_IDENTITY_NUMBER;
 
 @SuppressWarnings({"unused", "PMD.GodClass", "PMD.TooManyFields", "PMD.ExcessivePublicCount",
-        "PMD.CouplingBetweenObjects"})
+                   "PMD.CouplingBetweenObjects"})
 @JacocoGenerated
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class CristinPerson implements JsonSerializable {

--- a/cristin-person/src/main/java/no/unit/nva/cristin/person/model/nva/Award.java
+++ b/cristin-person/src/main/java/no/unit/nva/cristin/person/model/nva/Award.java
@@ -1,9 +1,9 @@
 package no.unit.nva.cristin.person.model.nva;
 
 import static no.unit.nva.cristin.model.JsonPropertyNames.AFFILIATION;
+import static no.unit.nva.cristin.model.JsonPropertyNames.AWARD_FOR;
 import static no.unit.nva.cristin.model.JsonPropertyNames.DISTRIBUTION;
 import static no.unit.nva.cristin.model.JsonPropertyNames.NAME;
-import static no.unit.nva.cristin.model.JsonPropertyNames.TYPE;
 import static no.unit.nva.cristin.model.JsonPropertyNames.YEAR;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import no.unit.nva.commons.json.JsonSerializable;
@@ -12,7 +12,7 @@ import no.unit.nva.model.TypedLabel;
 
 public record Award(@JsonProperty(NAME) String name,
                     @JsonProperty(YEAR) int year,
-                    @JsonProperty(TYPE) TypedLabel type,
+                    @JsonProperty(AWARD_FOR) TypedLabel awardFor,
                     @JsonProperty(DISTRIBUTION) TypedLabel distribution,
                     @JsonProperty(AFFILIATION) Organization affiliation) implements JsonSerializable {
 

--- a/cristin-person/src/main/java/no/unit/nva/cristin/person/model/nva/adapter/AwardToCristinFormat.java
+++ b/cristin-person/src/main/java/no/unit/nva/cristin/person/model/nva/adapter/AwardToCristinFormat.java
@@ -23,7 +23,7 @@ public class AwardToCristinFormat implements Function<Award, CristinAward> {
 
         var title = award.name();
         var year = award.year();
-        var type = generateCristinAwardTypeWithoutLabel(award.type());
+        var type = generateCristinAwardTypeWithoutLabel(award.awardFor());
         var distribution = generateCristinAwardDistributionWithoutLabel(award.distribution());
         var affiliation = generateCristinAffiliation(award.affiliation());
 

--- a/cristin-person/src/test/java/no/unit/nva/cristin/person/fetch/personFetch.feature
+++ b/cristin-person/src/test/java/no/unit/nva/cristin/person/fetch/personFetch.feature
@@ -199,8 +199,8 @@ Feature: API tests for Cristin Person fetch
     And match response.awards == '#present'
     And match response.awards[0].name == 'My first award'
     And match response.awards[0].year == 2014
-    And match response.awards[0].type.type == 'ResearchDissemination'
-    And match response.awards[0].type.label == '#present'
+    And match response.awards[0].awardFor.type == 'ResearchDissemination'
+    And match response.awards[0].awardFor.label == '#present'
     And match response.awards[0].distribution.type == 'National'
     And match response.awards[0].distribution.label == '#present'
     And match response.awards[0].affiliation == '#present'

--- a/cristin-person/src/test/java/no/unit/nva/cristin/person/update/cristinPersonUpdate.feature
+++ b/cristin-person/src/test/java/no/unit/nva/cristin/person/update/cristinPersonUpdate.feature
@@ -65,7 +65,7 @@ Feature: API tests for Cristin Person Update
         {
           'name': 'My first award',
           'year': '2014',
-          'type': {
+          'awardFor': {
             'type': 'ResearchDissemination'
           },
           'distribution': {

--- a/cristin-person/src/test/resources/nvaApiGetPersonNviVerified.json
+++ b/cristin-person/src/test/resources/nvaApiGetPersonNviVerified.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://example.org/person-context.json",
+  "@context": "https://bibsysdev.github.io/src/person-context.json",
   "id": "https://api.dev.nva.aws.unit.no/cristin/person/359084",
   "type": "Person",
   "identifiers": [

--- a/cristin-person/src/test/resources/nvaApiGetPersonResponse.json
+++ b/cristin-person/src/test/resources/nvaApiGetPersonResponse.json
@@ -1,5 +1,5 @@
 {
-  "@context": "https://example.org/person-context.json",
+  "@context": "https://bibsysdev.github.io/src/person-context.json",
   "id": "https://api.dev.nva.aws.unit.no/cristin/person/359084",
   "type": "Person",
   "identifiers": [
@@ -110,7 +110,7 @@
     {
       "name": "My first award",
       "year": 2019,
-      "type": {
+      "awardFor": {
         "type": "Research",
         "label": {
           "en": "Research activity",
@@ -132,7 +132,7 @@
     {
       "name": "My second award",
       "year": 2016,
-      "type": {
+      "awardFor": {
         "type": "Research",
         "label": {
           "en": "Research activity",
@@ -154,7 +154,7 @@
     {
       "name": "My third award",
       "year": 2014,
-      "type": {
+      "awardFor": {
         "type": "ResearchDissemination",
         "label": {
           "en": "Dissemination of research results",

--- a/cristin-person/src/test/resources/nvaApiQueryPersonResponse.json
+++ b/cristin-person/src/test/resources/nvaApiQueryPersonResponse.json
@@ -119,7 +119,7 @@
         {
           "name": "My first award",
           "year": 2019,
-          "type": {
+          "awardFor": {
             "type": "Research",
             "label": {
               "en": "Research activity",
@@ -141,7 +141,7 @@
         {
           "name": "My second award",
           "year": 2016,
-          "type": {
+          "awardFor": {
             "type": "Research",
             "label": {
               "en": "Research activity",
@@ -163,7 +163,7 @@
         {
           "name": "My third award",
           "year": 2014,
-          "type": {
+          "awardFor": {
             "type": "ResearchDissemination",
             "label": {
               "en": "Dissemination of research results",
@@ -295,7 +295,7 @@
         {
           "name": "My first award",
           "year": 2019,
-          "type": {
+          "awardFor": {
             "type": "Research",
             "label": {
               "en": "Research activity",
@@ -317,7 +317,7 @@
         {
           "name": "My second award",
           "year": 2016,
-          "type": {
+          "awardFor": {
             "type": "Research",
             "label": {
               "en": "Research activity",
@@ -339,7 +339,7 @@
         {
           "name": "My third award",
           "year": 2014,
-          "type": {
+          "awardFor": {
             "type": "ResearchDissemination",
             "label": {
               "en": "Dissemination of research results",

--- a/cristin-person/src/test/resources/nvaApiUpdateOwnPersonRequest.json
+++ b/cristin-person/src/test/resources/nvaApiUpdateOwnPersonRequest.json
@@ -37,7 +37,7 @@
     {
       "name": "My first award",
       "year": 2019,
-      "type": {
+      "awardFor": {
         "type": "Research",
         "label": {
           "en": "Research activity",

--- a/cristin-person/src/test/resources/nvaApiUpdatePersonAsAdminRequest.json
+++ b/cristin-person/src/test/resources/nvaApiUpdatePersonAsAdminRequest.json
@@ -57,7 +57,7 @@
     {
       "name": "My first award",
       "year": 2019,
-      "type": {
+      "awardFor": {
         "type": "Research",
         "label": {
           "en": "Research activity",


### PR DESCRIPTION
- this is a breaking change for the API, but the data is unparseable and is therefore a bug (it will likely break loading into RDF models so no Person with an award can be expanded)
- `type` is a reserved word in NVA JSON-LD (it aliases the `@type` JSON-LD keyword)
- `type` was used to represent a relationship between an award and what the award was awarded for; `type`-> `awardFor`
- JSON-LD context did not exist, now it does; `https://example.org/person-context.json`-> `https://bibsysdev.github.io/src/person-context.json`
- New example: https://tinyurl.com/preview/27c39dsn
- Fixed one checkstyle warning