### PR TITLE
NP-49858 Add MANAGE_ALL_PROJECTS to ProjectUpdate validation

### DIFF
--- a/cristin-project/src/main/java/no/unit/nva/cristin/projects/update/UpdateCristinProjectHandler.java
+++ b/cristin-project/src/main/java/no/unit/nva/cristin/projects/update/UpdateCristinProjectHandler.java
@@ -32,7 +32,6 @@ import static no.unit.nva.utils.LogUtils.LOG_IDENTIFIERS;
 import static no.unit.nva.utils.LogUtils.extractCristinIdentifier;
 import static no.unit.nva.utils.LogUtils.extractOrgIdentifier;
 import static nva.commons.apigateway.AccessRight.MANAGE_ALL_PROJECTS;
-import static nva.commons.apigateway.AccessRight.MANAGE_OWN_RESOURCES;
 
 public class UpdateCristinProjectHandler extends ApiGatewayHandler<String, Void> {
 

--- a/cristin-project/src/main/java/no/unit/nva/cristin/projects/update/UpdateCristinProjectHandler.java
+++ b/cristin-project/src/main/java/no/unit/nva/cristin/projects/update/UpdateCristinProjectHandler.java
@@ -31,6 +31,8 @@ import static no.unit.nva.cristin.projects.update.UpdateProjectResourceAccessChe
 import static no.unit.nva.utils.LogUtils.LOG_IDENTIFIERS;
 import static no.unit.nva.utils.LogUtils.extractCristinIdentifier;
 import static no.unit.nva.utils.LogUtils.extractOrgIdentifier;
+import static nva.commons.apigateway.AccessRight.MANAGE_ALL_PROJECTS;
+import static nva.commons.apigateway.AccessRight.MANAGE_OWN_RESOURCES;
 
 public class UpdateCristinProjectHandler extends ApiGatewayHandler<String, Void> {
 
@@ -96,9 +98,17 @@ public class UpdateCristinProjectHandler extends ApiGatewayHandler<String, Void>
 
     @Override
     protected void validateRequest(String input, RequestInfo requestInfo, Context context) throws ApiGatewayException {
+        if (canEditAllProjects(requestInfo)) {
+            return;
+        }
+
         if (missingHandlerOrResourceAccess(requestInfo)) {
             throw new ForbiddenException();
         }
+    }
+
+    private boolean canEditAllProjects(RequestInfo requestInfo) {
+        return requestInfo.userIsAuthorized(MANAGE_ALL_PROJECTS);
     }
 
     private boolean noSupportedValuesPresent(ObjectNode cristinJson) {

--- a/cristin-project/src/test/java/no/unit/nva/cristin/projects/update/UpdateCristinProjectHandlerTest.java
+++ b/cristin-project/src/test/java/no/unit/nva/cristin/projects/update/UpdateCristinProjectHandlerTest.java
@@ -43,7 +43,9 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static no.unit.nva.validation.PatchValidator.COULD_NOT_PARSE_LANGUAGE_FIELD;
 import static no.unit.nva.validation.PatchValidator.ILLEGAL_VALUE_FOR_PROPERTY;
+import static nva.commons.apigateway.AccessRight.MANAGE_ALL_PROJECTS;
 import static nva.commons.apigateway.AccessRight.MANAGE_OWN_RESOURCES;
+import static nva.commons.apigateway.AccessRight.MANAGE_RESOURCES_ALL;
 import static nva.commons.apigateway.MediaTypes.APPLICATION_PROBLEM_JSON;
 import static nva.commons.core.StringUtils.EMPTY_STRING;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -245,6 +247,18 @@ class UpdateCristinProjectHandlerTest {
         mockFetchResponse(fetchedProjectJson);
 
         var input = generateInputWithPayloadAndRequesterPersonCristinId(MANAGE_OWN_RESOURCES);
+        handler.handleRequest(input, output, context);
+        var response =  GatewayResponse.fromOutputStream(output, Void.class);
+
+        assertThat(response.getStatusCode(), equalTo(HTTP_NO_CONTENT));
+    }
+
+    @Test
+    void shouldAllowUserToUpdateAnyProjectWhenHavingAccessRightManageAllProjects() throws Exception {
+        var fetchedProjectJson = basicCristinProject().toString();
+        mockFetchResponse(fetchedProjectJson);
+
+        var input = generateInputWithPayloadAndRequesterPersonCristinId(MANAGE_ALL_PROJECTS);
         handler.handleRequest(input, output, context);
         var response =  GatewayResponse.fromOutputStream(output, Void.class);
 

--- a/cristin-project/src/test/java/no/unit/nva/cristin/projects/update/UpdateCristinProjectHandlerTest.java
+++ b/cristin-project/src/test/java/no/unit/nva/cristin/projects/update/UpdateCristinProjectHandlerTest.java
@@ -45,7 +45,6 @@ import static no.unit.nva.validation.PatchValidator.COULD_NOT_PARSE_LANGUAGE_FIE
 import static no.unit.nva.validation.PatchValidator.ILLEGAL_VALUE_FOR_PROPERTY;
 import static nva.commons.apigateway.AccessRight.MANAGE_ALL_PROJECTS;
 import static nva.commons.apigateway.AccessRight.MANAGE_OWN_RESOURCES;
-import static nva.commons.apigateway.AccessRight.MANAGE_RESOURCES_ALL;
 import static nva.commons.apigateway.MediaTypes.APPLICATION_PROBLEM_JSON;
 import static nva.commons.core.StringUtils.EMPTY_STRING;
 import static org.hamcrest.CoreMatchers.containsString;


### PR DESCRIPTION
Allow a user with AccessRight `MANAGE_ALL_PROJECTS` to update any project. This AccessRight will be added to the Editor role.