### PR TITLE
returning image url with nva fetch person picture endpoing value

### DIFF
--- a/cristin-person/src/main/java/no/unit/nva/cristin/person/model/cristin/CristinPerson.java
+++ b/cristin-person/src/main/java/no/unit/nva/cristin/person/model/cristin/CristinPerson.java
@@ -8,6 +8,7 @@ import static no.unit.nva.cristin.model.Constants.DOMAIN_NAME;
 import static no.unit.nva.cristin.model.Constants.HTTPS;
 import static no.unit.nva.cristin.model.Constants.PERSON_PATH_NVA;
 import static no.unit.nva.cristin.person.model.nva.JsonPropertyNames.NATIONAL_IDENTITY_NUMBER;
+import static no.unit.nva.cristin.person.model.nva.JsonPropertyNames.PICTURE;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
@@ -268,16 +269,17 @@ public class CristinPerson implements JsonSerializable {
   }
 
   public Person.Builder toPersonBuilder() {
+    var id = extractIdUri();
     if (Boolean.TRUE.equals(getReserved())) {
       // Also preserving size of hits from upstream
-      return new Person.Builder().withId(extractIdUri());
+      return new Person.Builder().withId(id);
     }
     return new Person.Builder()
-        .withId(extractIdUri())
+        .withId(id)
         .withIdentifiers(extractNonAuthorizedIdentifiers())
         .withNames(extractNames())
         .withContactDetails(extractContactDetails())
-        .withImage(extractImage())
+        .withImage(extractImage(id))
         .withAffiliations(extractAffiliations())
         .withVerified(extractVerified())
         .withKeywords(extractKeywords())
@@ -300,12 +302,13 @@ public class CristinPerson implements JsonSerializable {
   }
 
   public Person.Builder toPersonBuilderWithAuthorizedFields() {
+    var id = extractIdUri();
     return new Person.Builder()
-        .withId(extractIdUri())
+        .withId(id)
         .withIdentifiers(extractAuthorizedIdentifiers())
         .withNames(extractNames())
         .withContactDetails(extractContactDetails())
-        .withImage(extractImage())
+        .withImage(extractImage(id))
         .withAffiliations(extractAffiliations())
         .withReserved(getReserved())
         .withEmployments(extractEmployments())
@@ -377,8 +380,10 @@ public class CristinPerson implements JsonSerializable {
     return names;
   }
 
-  private URI extractImage() {
-    return getPictureUrl().map(UriWrapper::fromUri).map(UriWrapper::getUri).orElse(null);
+  private URI extractImage(URI id) {
+    return getPictureUrl()
+        .map(value -> UriWrapper.fromUri(id).addChild(PICTURE).getUri())
+        .orElse(null);
   }
 
   private List<Affiliation> extractAffiliations() {

--- a/cristin-person/src/main/java/no/unit/nva/cristin/person/model/nva/JsonPropertyNames.java
+++ b/cristin-person/src/main/java/no/unit/nva/cristin/person/model/nva/JsonPropertyNames.java
@@ -27,4 +27,5 @@ public class JsonPropertyNames {
   public static final String COLLABORATION = "collaboration";
   public static final String COUNTRIES = "countries";
   public static final String AWARDS = "awards";
+  public static final String PICTURE = "picture";
 }

--- a/cristin-person/src/test/resources/nvaApiGetPersonResponse.json
+++ b/cristin-person/src/test/resources/nvaApiGetPersonResponse.json
@@ -35,7 +35,7 @@
     "email": "kjell@ola.no",
     "webPage": "https://www.kjell.no"
   },
-  "image": "https://api.cristin.no/v2/persons/359084/picture",
+  "image": "https://api.dev.nva.aws.unit.no/cristin/person/359084/picture",
   "affiliations": [
     {
       "type": "Affiliation",

--- a/cristin-person/src/test/resources/nvaApiQueryPersonResponse.json
+++ b/cristin-person/src/test/resources/nvaApiQueryPersonResponse.json
@@ -44,7 +44,7 @@
         "email": "kjell@ola.no",
         "webPage": "https://www.kjell.no"
       },
-      "image": "https://api.cristin.no/v2/persons/359084/picture",
+      "image": "https://api.dev.nva.aws.unit.no/cristin/person/359084/picture",
       "affiliations": [
         {
           "type": "Affiliation",
@@ -220,7 +220,7 @@
         "email": "kjell@ola.no",
         "webPage": "https://www.kjell.no"
       },
-      "image": "https://api.cristin.no/v2/persons/359084/picture",
+      "image": "https://api.dev.nva.aws.unit.no/cristin/person/359084/picture",
       "affiliations": [
         {
           "type": "Affiliation",


### PR DESCRIPTION
It seems that we already serve "image" as part of person response. Updating its value to nva fetch-cristin-person-picture endpoint. Frontend should use this value to not call fetch picture endpoint when image is missing. 