### PR TITLE
fix(deps): upgrade nva-commons to 2.8.1 to fix JavaTimeModule NoClassDefFoundError

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.console=verbose
 org.gradle.warning.mode=all
 
 # Version of `nva-commons` used for version catalog and dependencies
-nvaCommonsVersion=2.7.3
+nvaCommonsVersion=2.8.1
 
 # Allow Gradle to use more memory than the default (needed for buildHealth command)
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m


### PR DESCRIPTION
Upgrades nva-commons from 2.7.3 to 2.8.1 to resolve a `NoClassDefFoundError` for `JavaTimeModule` that crashes `UpdateUnitsHandler` in the deployed Lambda.

- `cristin-intermediate-storage` uses `JsonUtils.dtoObjectMapper`, which registers `JavaTimeModule` (jackson-datatype-jsr310)
- In nva-commons 2.7.3 the json module declared jsr310/jdk8 as `compileOnly`, so the jars were not on the Lambda runtime classpath
- nva-commons 2.8.1 (BIBSYSDEV/nva-commons#607) changes these to `implementation`, so they are now pulled in transitively at runtime
- This brings `JavaTimeModule` into the Lambda zip and fixes the crash