### PR TITLE
fix(cristin-person): return 307 for person merged into another #NP-51564

### DIFF
--- a/cristin-commons/src/main/java/no/unit/nva/exception/TemporaryRedirectException.java
+++ b/cristin-commons/src/main/java/no/unit/nva/exception/TemporaryRedirectException.java
@@ -6,7 +6,8 @@ import nva.commons.apigateway.exceptions.RedirectException;
 public class TemporaryRedirectException extends RedirectException {
 
   public static final int TEMPORARY_REDIRECT = 307;
-  public static final String ERROR_MESSAGE_TEMPORARY_REDIRECT =
+
+  private static final String ERROR_MESSAGE_TEMPORARY_REDIRECT =
       "The requested resource is temporarily available at '%s'";
 
   private final URI location;

--- a/cristin-commons/src/main/java/no/unit/nva/exception/TemporaryRedirectException.java
+++ b/cristin-commons/src/main/java/no/unit/nva/exception/TemporaryRedirectException.java
@@ -1,0 +1,28 @@
+package no.unit.nva.exception;
+
+import java.net.URI;
+import nva.commons.apigateway.exceptions.RedirectException;
+
+public class TemporaryRedirectException extends RedirectException {
+
+  public static final int TEMPORARY_REDIRECT = 307;
+  public static final String ERROR_MESSAGE_TEMPORARY_REDIRECT =
+      "The requested resource is temporarily available at '%s'";
+
+  private final URI location;
+
+  public TemporaryRedirectException(URI location) {
+    super(ERROR_MESSAGE_TEMPORARY_REDIRECT.formatted(location));
+    this.location = location;
+  }
+
+  @Override
+  public URI getLocation() {
+    return location;
+  }
+
+  @Override
+  protected Integer statusCode() {
+    return TEMPORARY_REDIRECT;
+  }
+}

--- a/cristin-person/src/main/java/no/unit/nva/cristin/person/client/CristinPersonApiClient.java
+++ b/cristin-person/src/main/java/no/unit/nva/cristin/person/client/CristinPersonApiClient.java
@@ -297,38 +297,10 @@ public class CristinPersonApiClient extends ApiClient
     return toCristinPerson(identifier, fetchGetResult(uri));
   }
 
-  private CristinPerson toCristinPerson(String identifier, HttpResponse<String> response)
-      throws ApiGatewayException {
-    checkHttpStatusCode(getNvaApiId(identifier, PERSON), response.statusCode(), response.body());
-    throwRedirectWhenPersonIsMergedIntoAnother(identifier, response);
-    return getDeserializedResponse(response, CristinPerson.class);
-  }
-
   private URI getCorrectUriForIdentifier(String identifier) {
     return isOrcid(identifier)
         ? CristinPersonQuery.fromOrcid(identifier)
         : CristinPersonQuery.fromId(identifier);
-  }
-
-  private void throwRedirectWhenPersonIsMergedIntoAnother(
-      String requestedIdentifier, HttpResponse<String> response) throws TemporaryRedirectException {
-
-    var redirectedToIdentifier = extractPersonIdentifier(response.uri());
-    if (upstreamRedirectedToAnotherCristinPerson(requestedIdentifier, redirectedToIdentifier)) {
-      logger.info(LOG_PERSON_MERGED_INTO_ANOTHER, requestedIdentifier, redirectedToIdentifier);
-      throw new TemporaryRedirectException(getNvaApiId(redirectedToIdentifier, PERSON));
-    }
-  }
-
-  private boolean upstreamRedirectedToAnotherCristinPerson(
-      String requestedIdentifier, String redirectedToIdentifier) {
-    return isPositiveInteger(requestedIdentifier)
-        && isPositiveInteger(redirectedToIdentifier)
-        && Integer.parseInt(requestedIdentifier) != Integer.parseInt(redirectedToIdentifier);
-  }
-
-  private String extractPersonIdentifier(URI uri) {
-    return nonNull(uri) && isNotBlank(uri.getPath()) ? extractLastPathElement(uri) : null;
   }
 
   /**
@@ -380,6 +352,34 @@ public class CristinPersonApiClient extends ApiClient
         .map(CristinPerson::getCristinPersonId)
         .map(CristinPersonQuery::fromId)
         .orElseThrow();
+  }
+
+  private CristinPerson toCristinPerson(String identifier, HttpResponse<String> response)
+      throws ApiGatewayException {
+    checkHttpStatusCode(getNvaApiId(identifier, PERSON), response.statusCode(), response.body());
+    throwRedirectWhenPersonIsMergedIntoAnother(identifier, response);
+    return getDeserializedResponse(response, CristinPerson.class);
+  }
+
+  private void throwRedirectWhenPersonIsMergedIntoAnother(
+      String requestedIdentifier, HttpResponse<String> response) throws TemporaryRedirectException {
+
+    var redirectedToIdentifier = extractPersonIdentifier(response.uri());
+    if (upstreamRedirectedToAnotherCristinPerson(requestedIdentifier, redirectedToIdentifier)) {
+      logger.info(LOG_PERSON_MERGED_INTO_ANOTHER, requestedIdentifier, redirectedToIdentifier);
+      throw new TemporaryRedirectException(getNvaApiId(redirectedToIdentifier, PERSON));
+    }
+  }
+
+  private boolean upstreamRedirectedToAnotherCristinPerson(
+      String requestedIdentifier, String redirectedToIdentifier) {
+    return isPositiveInteger(requestedIdentifier)
+        && isPositiveInteger(redirectedToIdentifier)
+        && Integer.parseInt(requestedIdentifier) != Integer.parseInt(redirectedToIdentifier);
+  }
+
+  private String extractPersonIdentifier(URI uri) {
+    return nonNull(uri) && isNotBlank(uri.getPath()) ? extractLastPathElement(uri) : null;
   }
 
   private URI idUriForIdentityNumber() {

--- a/cristin-person/src/main/java/no/unit/nva/cristin/person/client/CristinPersonApiClient.java
+++ b/cristin-person/src/main/java/no/unit/nva/cristin/person/client/CristinPersonApiClient.java
@@ -3,6 +3,7 @@ package no.unit.nva.cristin.person.client;
 import static java.util.Arrays.asList;
 import static no.unit.nva.client.HttpClientProvider.defaultHttpClient;
 import static no.unit.nva.cristin.common.Utils.isOrcid;
+import static no.unit.nva.cristin.common.Utils.isPositiveInteger;
 import static no.unit.nva.cristin.model.Constants.BASE_PATH;
 import static no.unit.nva.cristin.model.Constants.DOMAIN_NAME;
 import static no.unit.nva.cristin.model.Constants.HTTPS;
@@ -17,6 +18,7 @@ import static no.unit.nva.cristin.model.JsonPropertyNames.PAGE;
 import static no.unit.nva.cristin.person.model.nva.JsonPropertyNames.VERIFIED;
 import static no.unit.nva.utils.UriUtils.PERSON;
 import static no.unit.nva.utils.UriUtils.createIdUriFromParams;
+import static no.unit.nva.utils.UriUtils.extractLastPathElement;
 import static no.unit.nva.utils.UriUtils.getNvaApiId;
 import static nva.commons.core.attempt.Try.attempt;
 
@@ -35,10 +37,13 @@ import no.unit.nva.cristin.common.client.CristinAuthorizedQueryClient;
 import no.unit.nva.cristin.model.SearchResponse;
 import no.unit.nva.cristin.person.model.cristin.CristinPerson;
 import no.unit.nva.cristin.person.model.nva.Person;
+import no.unit.nva.exception.TemporaryRedirectException;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.NotFoundException;
 import nva.commons.core.attempt.Try;
 import nva.commons.core.paths.UriWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CristinPersonApiClient extends ApiClient
     implements ClientVersion, CristinAuthorizedQueryClient<Map<String, String>, Person> {
@@ -47,6 +52,10 @@ public class CristinPersonApiClient extends ApiClient
   public static final String ERROR_MESSAGE_NO_MATCH_FOUND_FOR_SUPPLIED_PAYLOAD =
       "No match found for supplied " + "payload";
   public static final String VERSION_ONE = "1";
+
+  private static final Logger logger = LoggerFactory.getLogger(CristinPersonApiClient.class);
+  private static final String LOG_PERSON_MERGED_INTO_ANOTHER =
+      "Upstream redirected person {} to person {}";
 
   /** Create CristinPersonApiClient with default HTTP client. */
   public CristinPersonApiClient() {
@@ -279,6 +288,7 @@ public class CristinPersonApiClient extends ApiClient
       throws ApiGatewayException {
     var uri = getCorrectUriForIdentifier(identifier);
     var response = fetchGetResultWithAuthentication(uri);
+    throwRedirectWhenPersonIsMergedIntoAnother(identifier, response);
     checkHttpStatusCode(getNvaApiId(identifier, PERSON), response.statusCode(), response.body());
     return getDeserializedResponse(response, CristinPerson.class);
   }
@@ -286,6 +296,7 @@ public class CristinPersonApiClient extends ApiClient
   protected CristinPerson getCristinPerson(String identifier) throws ApiGatewayException {
     var uri = getCorrectUriForIdentifier(identifier);
     var response = fetchGetResult(uri);
+    throwRedirectWhenPersonIsMergedIntoAnother(identifier, response);
     checkHttpStatusCode(getNvaApiId(identifier, PERSON), response.statusCode(), response.body());
     return getDeserializedResponse(response, CristinPerson.class);
   }
@@ -294,6 +305,23 @@ public class CristinPersonApiClient extends ApiClient
     return isOrcid(identifier)
         ? CristinPersonQuery.fromOrcid(identifier)
         : CristinPersonQuery.fromId(identifier);
+  }
+
+  private void throwRedirectWhenPersonIsMergedIntoAnother(
+      String requestedIdentifier, HttpResponse<String> response) throws TemporaryRedirectException {
+
+    var redirectedToIdentifier = extractLastPathElement(response.uri());
+    if (upstreamRedirectedToAnotherCristinPerson(requestedIdentifier, redirectedToIdentifier)) {
+      logger.info(LOG_PERSON_MERGED_INTO_ANOTHER, requestedIdentifier, redirectedToIdentifier);
+      throw new TemporaryRedirectException(getNvaApiId(redirectedToIdentifier, PERSON));
+    }
+  }
+
+  private boolean upstreamRedirectedToAnotherCristinPerson(
+      String requestedIdentifier, String redirectedToIdentifier) {
+    return isPositiveInteger(requestedIdentifier)
+        && isPositiveInteger(redirectedToIdentifier)
+        && !requestedIdentifier.equals(redirectedToIdentifier);
   }
 
   /**

--- a/cristin-person/src/main/java/no/unit/nva/cristin/person/client/CristinPersonApiClient.java
+++ b/cristin-person/src/main/java/no/unit/nva/cristin/person/client/CristinPersonApiClient.java
@@ -8,6 +8,7 @@ import static no.unit.nva.cristin.common.Utils.isPositiveInteger;
 import static no.unit.nva.cristin.model.Constants.BASE_PATH;
 import static no.unit.nva.cristin.model.Constants.DOMAIN_NAME;
 import static no.unit.nva.cristin.model.Constants.HTTPS;
+import static no.unit.nva.cristin.model.Constants.PERSONS_PATH;
 import static no.unit.nva.cristin.model.Constants.PERSON_CONTEXT;
 import static no.unit.nva.cristin.model.Constants.PERSON_PATH_NVA;
 import static no.unit.nva.cristin.model.Constants.PERSON_QUERY_CONTEXT;
@@ -21,7 +22,6 @@ import static no.unit.nva.utils.UriUtils.PERSON;
 import static no.unit.nva.utils.UriUtils.createIdUriFromParams;
 import static no.unit.nva.utils.UriUtils.extractLastPathElement;
 import static no.unit.nva.utils.UriUtils.getNvaApiId;
-import static nva.commons.core.StringUtils.isNotBlank;
 import static nva.commons.core.attempt.Try.attempt;
 
 import java.net.HttpURLConnection;
@@ -31,6 +31,7 @@ import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import no.unit.nva.client.ClientVersion;
@@ -58,6 +59,8 @@ public class CristinPersonApiClient extends ApiClient
   private static final Logger logger = LoggerFactory.getLogger(CristinPersonApiClient.class);
   private static final String LOG_PERSON_MERGED_INTO_ANOTHER =
       "Upstream redirected person {} to person {}";
+  private static final Pattern CRISTIN_PERSON_PATH =
+      Pattern.compile(".*/%s/[^/]+".formatted(PERSONS_PATH));
 
   /** Create CristinPersonApiClient with default HTTP client. */
   public CristinPersonApiClient() {
@@ -379,7 +382,13 @@ public class CristinPersonApiClient extends ApiClient
   }
 
   private String extractPersonIdentifier(URI uri) {
-    return nonNull(uri) && isNotBlank(uri.getPath()) ? extractLastPathElement(uri) : null;
+    return isCristinPersonResource(uri) ? extractLastPathElement(uri) : null;
+  }
+
+  private boolean isCristinPersonResource(URI uri) {
+    return nonNull(uri)
+        && nonNull(uri.getPath())
+        && CRISTIN_PERSON_PATH.matcher(uri.getPath()).matches();
   }
 
   private URI idUriForIdentityNumber() {

--- a/cristin-person/src/main/java/no/unit/nva/cristin/person/client/CristinPersonApiClient.java
+++ b/cristin-person/src/main/java/no/unit/nva/cristin/person/client/CristinPersonApiClient.java
@@ -60,7 +60,7 @@ public class CristinPersonApiClient extends ApiClient
   private static final String LOG_PERSON_MERGED_INTO_ANOTHER =
       "Upstream redirected person {} to person {}";
   private static final Pattern CRISTIN_PERSON_PATH =
-      Pattern.compile(".*/%s/[^/]+".formatted(PERSONS_PATH));
+      Pattern.compile(".*/%s/[^/]+/*".formatted(PERSONS_PATH), Pattern.CASE_INSENSITIVE);
 
   /** Create CristinPersonApiClient with default HTTP client. */
   public CristinPersonApiClient() {

--- a/cristin-person/src/main/java/no/unit/nva/cristin/person/client/CristinPersonApiClient.java
+++ b/cristin-person/src/main/java/no/unit/nva/cristin/person/client/CristinPersonApiClient.java
@@ -297,8 +297,8 @@ public class CristinPersonApiClient extends ApiClient
 
   private CristinPerson toCristinPerson(String identifier, HttpResponse<String> response)
       throws ApiGatewayException {
-    throwRedirectWhenPersonIsMergedIntoAnother(identifier, response);
     checkHttpStatusCode(getNvaApiId(identifier, PERSON), response.statusCode(), response.body());
+    throwRedirectWhenPersonIsMergedIntoAnother(identifier, response);
     return getDeserializedResponse(response, CristinPerson.class);
   }
 

--- a/cristin-person/src/main/java/no/unit/nva/cristin/person/client/CristinPersonApiClient.java
+++ b/cristin-person/src/main/java/no/unit/nva/cristin/person/client/CristinPersonApiClient.java
@@ -324,7 +324,7 @@ public class CristinPersonApiClient extends ApiClient
       String requestedIdentifier, String redirectedToIdentifier) {
     return isPositiveInteger(requestedIdentifier)
         && isPositiveInteger(redirectedToIdentifier)
-        && !requestedIdentifier.equals(redirectedToIdentifier);
+        && Integer.parseInt(requestedIdentifier) != Integer.parseInt(redirectedToIdentifier);
   }
 
   private String extractPersonIdentifier(URI uri) {

--- a/cristin-person/src/main/java/no/unit/nva/cristin/person/client/CristinPersonApiClient.java
+++ b/cristin-person/src/main/java/no/unit/nva/cristin/person/client/CristinPersonApiClient.java
@@ -1,6 +1,7 @@
 package no.unit.nva.cristin.person.client;
 
 import static java.util.Arrays.asList;
+import static java.util.Objects.nonNull;
 import static no.unit.nva.client.HttpClientProvider.defaultHttpClient;
 import static no.unit.nva.cristin.common.Utils.isOrcid;
 import static no.unit.nva.cristin.common.Utils.isPositiveInteger;
@@ -20,6 +21,7 @@ import static no.unit.nva.utils.UriUtils.PERSON;
 import static no.unit.nva.utils.UriUtils.createIdUriFromParams;
 import static no.unit.nva.utils.UriUtils.extractLastPathElement;
 import static no.unit.nva.utils.UriUtils.getNvaApiId;
+import static nva.commons.core.StringUtils.isNotBlank;
 import static nva.commons.core.attempt.Try.attempt;
 
 import java.net.HttpURLConnection;
@@ -311,7 +313,7 @@ public class CristinPersonApiClient extends ApiClient
   private void throwRedirectWhenPersonIsMergedIntoAnother(
       String requestedIdentifier, HttpResponse<String> response) throws TemporaryRedirectException {
 
-    var redirectedToIdentifier = extractLastPathElement(response.uri());
+    var redirectedToIdentifier = extractPersonIdentifier(response.uri());
     if (upstreamRedirectedToAnotherCristinPerson(requestedIdentifier, redirectedToIdentifier)) {
       logger.info(LOG_PERSON_MERGED_INTO_ANOTHER, requestedIdentifier, redirectedToIdentifier);
       throw new TemporaryRedirectException(getNvaApiId(redirectedToIdentifier, PERSON));
@@ -323,6 +325,10 @@ public class CristinPersonApiClient extends ApiClient
     return isPositiveInteger(requestedIdentifier)
         && isPositiveInteger(redirectedToIdentifier)
         && !requestedIdentifier.equals(redirectedToIdentifier);
+  }
+
+  private String extractPersonIdentifier(URI uri) {
+    return nonNull(uri) && isNotBlank(uri.getPath()) ? extractLastPathElement(uri) : null;
   }
 
   /**

--- a/cristin-person/src/main/java/no/unit/nva/cristin/person/client/CristinPersonApiClient.java
+++ b/cristin-person/src/main/java/no/unit/nva/cristin/person/client/CristinPersonApiClient.java
@@ -287,15 +287,16 @@ public class CristinPersonApiClient extends ApiClient
   protected CristinPerson getCristinPersonWithAuthentication(String identifier)
       throws ApiGatewayException {
     var uri = getCorrectUriForIdentifier(identifier);
-    var response = fetchGetResultWithAuthentication(uri);
-    throwRedirectWhenPersonIsMergedIntoAnother(identifier, response);
-    checkHttpStatusCode(getNvaApiId(identifier, PERSON), response.statusCode(), response.body());
-    return getDeserializedResponse(response, CristinPerson.class);
+    return toCristinPerson(identifier, fetchGetResultWithAuthentication(uri));
   }
 
   protected CristinPerson getCristinPerson(String identifier) throws ApiGatewayException {
     var uri = getCorrectUriForIdentifier(identifier);
-    var response = fetchGetResult(uri);
+    return toCristinPerson(identifier, fetchGetResult(uri));
+  }
+
+  private CristinPerson toCristinPerson(String identifier, HttpResponse<String> response)
+      throws ApiGatewayException {
     throwRedirectWhenPersonIsMergedIntoAnother(identifier, response);
     checkHttpStatusCode(getNvaApiId(identifier, PERSON), response.statusCode(), response.body());
     return getDeserializedResponse(response, CristinPerson.class);

--- a/cristin-person/src/main/java/no/unit/nva/cristin/person/client/CristinPersonApiClient.java
+++ b/cristin-person/src/main/java/no/unit/nva/cristin/person/client/CristinPersonApiClient.java
@@ -1,14 +1,12 @@
 package no.unit.nva.cristin.person.client;
 
 import static java.util.Arrays.asList;
-import static java.util.Objects.nonNull;
 import static no.unit.nva.client.HttpClientProvider.defaultHttpClient;
 import static no.unit.nva.cristin.common.Utils.isOrcid;
 import static no.unit.nva.cristin.common.Utils.isPositiveInteger;
 import static no.unit.nva.cristin.model.Constants.BASE_PATH;
 import static no.unit.nva.cristin.model.Constants.DOMAIN_NAME;
 import static no.unit.nva.cristin.model.Constants.HTTPS;
-import static no.unit.nva.cristin.model.Constants.PERSONS_PATH;
 import static no.unit.nva.cristin.model.Constants.PERSON_CONTEXT;
 import static no.unit.nva.cristin.model.Constants.PERSON_PATH_NVA;
 import static no.unit.nva.cristin.model.Constants.PERSON_QUERY_CONTEXT;
@@ -20,8 +18,8 @@ import static no.unit.nva.cristin.model.JsonPropertyNames.PAGE;
 import static no.unit.nva.cristin.person.model.nva.JsonPropertyNames.VERIFIED;
 import static no.unit.nva.utils.UriUtils.PERSON;
 import static no.unit.nva.utils.UriUtils.createIdUriFromParams;
-import static no.unit.nva.utils.UriUtils.extractLastPathElement;
 import static no.unit.nva.utils.UriUtils.getNvaApiId;
+import static nva.commons.core.StringUtils.isNotBlank;
 import static nva.commons.core.attempt.Try.attempt;
 
 import java.net.HttpURLConnection;
@@ -31,7 +29,6 @@ import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import no.unit.nva.client.ClientVersion;
@@ -57,10 +54,8 @@ public class CristinPersonApiClient extends ApiClient
   public static final String VERSION_ONE = "1";
 
   private static final Logger logger = LoggerFactory.getLogger(CristinPersonApiClient.class);
-  private static final String LOG_PERSON_MERGED_INTO_ANOTHER =
-      "Upstream redirected person {} to person {}";
-  private static final Pattern CRISTIN_PERSON_PATH =
-      Pattern.compile(".*/%s/[^/]+/*".formatted(PERSONS_PATH), Pattern.CASE_INSENSITIVE);
+  private static final String LOG_REDIRECTING_TO_CANONICAL_PERSON =
+      "Redirecting requested person {} to canonical person {}";
 
   /** Create CristinPersonApiClient with default HTTP client. */
   public CristinPersonApiClient() {
@@ -360,35 +355,25 @@ public class CristinPersonApiClient extends ApiClient
   private CristinPerson toCristinPerson(String identifier, HttpResponse<String> response)
       throws ApiGatewayException {
     checkHttpStatusCode(getNvaApiId(identifier, PERSON), response.statusCode(), response.body());
-    throwRedirectWhenPersonIsMergedIntoAnother(identifier, response);
-    return getDeserializedResponse(response, CristinPerson.class);
+    var cristinPerson = getDeserializedResponse(response, CristinPerson.class);
+    throwRedirectWhenIdentifierIsNotCanonical(identifier, cristinPerson);
+    return cristinPerson;
   }
 
-  private void throwRedirectWhenPersonIsMergedIntoAnother(
-      String requestedIdentifier, HttpResponse<String> response) throws TemporaryRedirectException {
+  private void throwRedirectWhenIdentifierIsNotCanonical(
+      String requestedIdentifier, CristinPerson cristinPerson) throws TemporaryRedirectException {
 
-    var redirectedToIdentifier = extractPersonIdentifier(response.uri());
-    if (upstreamRedirectedToAnotherCristinPerson(requestedIdentifier, redirectedToIdentifier)) {
-      logger.info(LOG_PERSON_MERGED_INTO_ANOTHER, requestedIdentifier, redirectedToIdentifier);
-      throw new TemporaryRedirectException(getNvaApiId(redirectedToIdentifier, PERSON));
+    var canonicalIdentifier = cristinPerson.getCristinPersonId();
+    if (identifierIsNotCanonical(requestedIdentifier, canonicalIdentifier)) {
+      logger.info(LOG_REDIRECTING_TO_CANONICAL_PERSON, requestedIdentifier, canonicalIdentifier);
+      throw new TemporaryRedirectException(getNvaApiId(canonicalIdentifier, PERSON));
     }
   }
 
-  private boolean upstreamRedirectedToAnotherCristinPerson(
-      String requestedIdentifier, String redirectedToIdentifier) {
+  private boolean identifierIsNotCanonical(String requestedIdentifier, String canonicalIdentifier) {
     return isPositiveInteger(requestedIdentifier)
-        && isPositiveInteger(redirectedToIdentifier)
-        && Integer.parseInt(requestedIdentifier) != Integer.parseInt(redirectedToIdentifier);
-  }
-
-  private String extractPersonIdentifier(URI uri) {
-    return isCristinPersonResource(uri) ? extractLastPathElement(uri) : null;
-  }
-
-  private boolean isCristinPersonResource(URI uri) {
-    return nonNull(uri)
-        && nonNull(uri.getPath())
-        && CRISTIN_PERSON_PATH.matcher(uri.getPath()).matches();
+        && isNotBlank(canonicalIdentifier)
+        && !requestedIdentifier.equals(canonicalIdentifier);
   }
 
   private URI idUriForIdentityNumber() {

--- a/cristin-person/src/main/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandler.java
+++ b/cristin-person/src/main/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandler.java
@@ -12,11 +12,13 @@ import static no.unit.nva.utils.LogUtils.extractCristinIdentifier;
 import static no.unit.nva.utils.LogUtils.extractOrgIdentifier;
 
 import com.amazonaws.services.lambda.runtime.Context;
+import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.List;
 import no.unit.nva.cristin.common.Utils;
 import no.unit.nva.cristin.person.client.CristinPersonApiClient;
 import no.unit.nva.cristin.person.model.nva.Person;
+import no.unit.nva.exception.TemporaryRedirectException;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.MediaType;
 import nva.commons.apigateway.RequestInfo;
@@ -70,6 +72,17 @@ public class FetchCristinPersonHandler extends ApiGatewayHandler<Void, Person> {
   @Override
   protected Integer getSuccessStatusCode(Void input, Person output) {
     return HttpURLConnection.HTTP_OK;
+  }
+
+  @Override
+  protected void handleExpectedException(
+      Context context, Void input, ApiGatewayException exception) throws IOException {
+
+    if (exception instanceof TemporaryRedirectException) {
+      writeExpectedFailure(input, exception, context.getAwsRequestId());
+    } else {
+      super.handleExpectedException(context, input, exception);
+    }
   }
 
   @Override

--- a/cristin-person/src/main/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandler.java
+++ b/cristin-person/src/main/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandler.java
@@ -18,12 +18,12 @@ import java.util.List;
 import no.unit.nva.cristin.common.Utils;
 import no.unit.nva.cristin.person.client.CristinPersonApiClient;
 import no.unit.nva.cristin.person.model.nva.Person;
-import no.unit.nva.exception.TemporaryRedirectException;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.MediaType;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.BadRequestException;
+import nva.commons.apigateway.exceptions.RedirectException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import org.slf4j.Logger;
@@ -78,7 +78,7 @@ public class FetchCristinPersonHandler extends ApiGatewayHandler<Void, Person> {
   protected void handleExpectedException(Context context, Void input, ApiGatewayException exception)
       throws IOException {
 
-    if (exception instanceof TemporaryRedirectException) {
+    if (exception instanceof RedirectException) {
       writeExpectedFailure(input, exception, context.getAwsRequestId());
     } else {
       super.handleExpectedException(context, input, exception);

--- a/cristin-person/src/main/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandler.java
+++ b/cristin-person/src/main/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandler.java
@@ -79,6 +79,7 @@ public class FetchCristinPersonHandler extends ApiGatewayHandler<Void, Person> {
       throws IOException {
 
     if (exception instanceof RedirectException) {
+      logger.info(exception.getMessage());
       writeExpectedFailure(input, exception, context.getAwsRequestId());
     } else {
       super.handleExpectedException(context, input, exception);

--- a/cristin-person/src/main/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandler.java
+++ b/cristin-person/src/main/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandler.java
@@ -75,8 +75,8 @@ public class FetchCristinPersonHandler extends ApiGatewayHandler<Void, Person> {
   }
 
   @Override
-  protected void handleExpectedException(
-      Context context, Void input, ApiGatewayException exception) throws IOException {
+  protected void handleExpectedException(Context context, Void input, ApiGatewayException exception)
+      throws IOException {
 
     if (exception instanceof TemporaryRedirectException) {
       writeExpectedFailure(input, exception, context.getAwsRequestId());

--- a/cristin-person/src/test/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandlerTest.java
+++ b/cristin-person/src/test/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandlerTest.java
@@ -101,6 +101,7 @@ public class FetchCristinPersonHandlerTest {
   private static final String EXPECTED_NVA_LOCATION_FOR_MERGED_PERSON =
       "https://%s/%s/person/%s".formatted(DOMAIN_NAME, BASE_PATH, MERGED_INTO_IDENTIFIER);
   private static final String CRISTIN_URI_WITHOUT_PATH = "https://www.cristin.no";
+  private static final String INSTITUTIONS_PATH = "institutions";
   private static final Map<String, String> PATH_PARAM_WITH_LEADING_ZEROS = Map.of(ID, "0012345");
 
   private CristinPersonApiClient apiClient;
@@ -453,6 +454,21 @@ public class FetchCristinPersonHandlerTest {
         .fetchGetResult(any(URI.class));
     handler = new FetchCristinPersonHandler(apiClient, environment);
     var gatewayResponse = sendQuery(ZERO_QUERY_PARAMS, PATH_PARAM_WITH_LEADING_ZEROS);
+
+    assertEquals(HTTP_OK, gatewayResponse.getStatusCode());
+  }
+
+  @Test
+  void shouldNotRedirectWhenUpstreamRespondsFromResourceThatIsNotAPerson() throws Exception {
+    apiClient = spy(apiClient);
+    doReturn(
+            HttpResponseFaker.respondedFromUri(
+                readFromResources(CRISTIN_GET_PERSON_RESPONSE_JSON),
+                getCristinUri(MERGED_INTO_IDENTIFIER, INSTITUTIONS_PATH)))
+        .when(apiClient)
+        .fetchGetResult(any(URI.class));
+    handler = new FetchCristinPersonHandler(apiClient, environment);
+    var gatewayResponse = sendQuery(ZERO_QUERY_PARAMS, VALID_PATH_PARAM);
 
     assertEquals(HTTP_OK, gatewayResponse.getStatusCode());
   }

--- a/cristin-person/src/test/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandlerTest.java
+++ b/cristin-person/src/test/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandlerTest.java
@@ -102,6 +102,8 @@ public class FetchCristinPersonHandlerTest {
       "https://%s/%s/person/%s".formatted(DOMAIN_NAME, BASE_PATH, MERGED_INTO_IDENTIFIER);
   private static final String CRISTIN_URI_WITHOUT_PATH = "https://www.cristin.no";
   private static final String INSTITUTIONS_PATH = "institutions";
+  private static final String PERSONS_PATH_CAPITALIZED = "Persons";
+  private static final String SLASH = "/";
   private static final Map<String, String> PATH_PARAM_WITH_LEADING_ZEROS = Map.of(ID, "0012345");
 
   private CristinPersonApiClient apiClient;
@@ -456,6 +458,42 @@ public class FetchCristinPersonHandlerTest {
     var gatewayResponse = sendQuery(ZERO_QUERY_PARAMS, PATH_PARAM_WITH_LEADING_ZEROS);
 
     assertEquals(HTTP_OK, gatewayResponse.getStatusCode());
+  }
+
+  @Test
+  void shouldRedirectWhenUpstreamPersonUriHasTrailingSlash() throws Exception {
+    apiClient = spy(apiClient);
+    doReturn(
+            HttpResponseFaker.respondedFromUri(
+                readFromResources(CRISTIN_GET_PERSON_RESPONSE_JSON),
+                URI.create(cristinUriForPerson(MERGED_INTO_IDENTIFIER) + SLASH)))
+        .when(apiClient)
+        .fetchGetResult(any(URI.class));
+    handler = new FetchCristinPersonHandler(apiClient, environment);
+    var gatewayResponse = sendQuery(ZERO_QUERY_PARAMS, VALID_PATH_PARAM);
+
+    assertEquals(TEMPORARY_REDIRECT, gatewayResponse.getStatusCode());
+    assertThat(
+        gatewayResponse.getHeaders().get(HttpHeaders.LOCATION),
+        equalTo(EXPECTED_NVA_LOCATION_FOR_MERGED_PERSON));
+  }
+
+  @Test
+  void shouldRedirectWhenUpstreamPersonPathIsSpelledWithDifferentCasing() throws Exception {
+    apiClient = spy(apiClient);
+    doReturn(
+            HttpResponseFaker.respondedFromUri(
+                readFromResources(CRISTIN_GET_PERSON_RESPONSE_JSON),
+                getCristinUri(MERGED_INTO_IDENTIFIER, PERSONS_PATH_CAPITALIZED)))
+        .when(apiClient)
+        .fetchGetResult(any(URI.class));
+    handler = new FetchCristinPersonHandler(apiClient, environment);
+    var gatewayResponse = sendQuery(ZERO_QUERY_PARAMS, VALID_PATH_PARAM);
+
+    assertEquals(TEMPORARY_REDIRECT, gatewayResponse.getStatusCode());
+    assertThat(
+        gatewayResponse.getHeaders().get(HttpHeaders.LOCATION),
+        equalTo(EXPECTED_NVA_LOCATION_FOR_MERGED_PERSON));
   }
 
   @Test

--- a/cristin-person/src/test/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandlerTest.java
+++ b/cristin-person/src/test/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandlerTest.java
@@ -94,6 +94,7 @@ public class FetchCristinPersonHandlerTest {
   private static final String EXPECTED_NVA_LOCATION_FOR_MERGED_PERSON =
       "https://api.dev.nva.aws.unit.no/cristin/person/5647";
   private static final String PERSONS_PATH = "persons";
+  private static final String CRISTIN_URI_WITHOUT_PATH = "https://www.cristin.no";
 
   private CristinPersonApiClient apiClient;
   private final Environment environment = new Environment();
@@ -419,6 +420,21 @@ public class FetchCristinPersonHandlerTest {
     var gatewayResponse = sendQuery(ZERO_QUERY_PARAMS, VALID_PATH_PARAM);
 
     assertEquals(HttpURLConnection.HTTP_NOT_FOUND, gatewayResponse.getStatusCode());
+  }
+
+  @Test
+  void shouldReturnPersonWhenUpstreamRespondsFromUriWithoutAnyPath() throws Exception {
+    apiClient = spy(apiClient);
+    doReturn(
+            HttpResponseFaker.respondedFromUri(
+                readFromResources(CRISTIN_GET_PERSON_RESPONSE_JSON),
+                URI.create(CRISTIN_URI_WITHOUT_PATH)))
+        .when(apiClient)
+        .fetchGetResult(any(URI.class));
+    handler = new FetchCristinPersonHandler(apiClient, environment);
+    var gatewayResponse = sendQuery(ZERO_QUERY_PARAMS, VALID_PATH_PARAM);
+
+    assertEquals(HTTP_OK, gatewayResponse.getStatusCode());
   }
 
   private HttpResponseFaker responseRedirectedToPerson(String identifier) {

--- a/cristin-person/src/test/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandlerTest.java
+++ b/cristin-person/src/test/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandlerTest.java
@@ -95,6 +95,7 @@ public class FetchCristinPersonHandlerTest {
       "https://api.dev.nva.aws.unit.no/cristin/person/5647";
   private static final String PERSONS_PATH = "persons";
   private static final String CRISTIN_URI_WITHOUT_PATH = "https://www.cristin.no";
+  private static final Map<String, String> PATH_PARAM_WITH_LEADING_ZEROS = Map.of(ID, "0012345");
 
   private CristinPersonApiClient apiClient;
   private final Environment environment = new Environment();
@@ -420,6 +421,19 @@ public class FetchCristinPersonHandlerTest {
     var gatewayResponse = sendQuery(ZERO_QUERY_PARAMS, VALID_PATH_PARAM);
 
     assertEquals(HttpURLConnection.HTTP_NOT_FOUND, gatewayResponse.getStatusCode());
+  }
+
+  @Test
+  void shouldNotRedirectWhenUpstreamIdentifierIsNumericallyEqualButWrittenDifferently()
+      throws Exception {
+    apiClient = spy(apiClient);
+    doReturn(responseRedirectedToPerson(VALID_PATH_PARAM.get(ID)))
+        .when(apiClient)
+        .fetchGetResult(any(URI.class));
+    handler = new FetchCristinPersonHandler(apiClient, environment);
+    var gatewayResponse = sendQuery(ZERO_QUERY_PARAMS, PATH_PARAM_WITH_LEADING_ZEROS);
+
+    assertEquals(HTTP_OK, gatewayResponse.getStatusCode());
   }
 
   @Test

--- a/cristin-person/src/test/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandlerTest.java
+++ b/cristin-person/src/test/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandlerTest.java
@@ -445,6 +445,8 @@ public class FetchCristinPersonHandlerTest {
     assertEquals(TEMPORARY_REDIRECT, gatewayResponse.getStatusCode());
     Assertions.assertThat(logRecorder.messages())
         .noneMatch(message -> message.contains(TemporaryRedirectException.class.getName()));
+    Assertions.assertThat(logRecorder.messages())
+        .anyMatch(message -> message.contains(EXPECTED_NVA_LOCATION_FOR_MERGED_PERSON));
   }
 
   @Test

--- a/cristin-person/src/test/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandlerTest.java
+++ b/cristin-person/src/test/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandlerTest.java
@@ -10,6 +10,7 @@ import static no.unit.nva.cristin.model.Constants.CRISTIN_API_URL;
 import static no.unit.nva.cristin.model.Constants.OBJECT_MAPPER;
 import static no.unit.nva.cristin.model.JsonPropertyNames.ID;
 import static no.unit.nva.cristin.person.model.nva.JsonPropertyNames.NATIONAL_IDENTITY_NUMBER;
+import static no.unit.nva.exception.TemporaryRedirectException.TEMPORARY_REDIRECT;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static nva.commons.apigateway.AccessRight.MANAGE_CUSTOMERS;
@@ -89,6 +90,10 @@ public class FetchCristinPersonHandlerTest {
   public static final String CRISTIN_PERSON_NVI_VERIFIED_JSON = "cristinPersonNviVerified.json";
   public static final String NVA_API_GET_PERSON_NVI_VERIFIED_JSON =
       "nvaApiGetPersonNviVerified.json";
+  private static final String MERGED_INTO_IDENTIFIER = "5647";
+  private static final String EXPECTED_NVA_LOCATION_FOR_MERGED_PERSON =
+      "https://api.dev.nva.aws.unit.no/cristin/person/5647";
+  private static final String PERSONS_PATH = "persons";
 
   private CristinPersonApiClient apiClient;
   private final Environment environment = new Environment();
@@ -353,6 +358,58 @@ public class FetchCristinPersonHandlerTest {
     var actual = sendQuery(ZERO_QUERY_PARAMS, VALID_PATH_PARAM).getBodyObject(Person.class);
 
     assertThat(actual.verified(), equalTo(false));
+  }
+
+  @Test
+  void shouldReturnTemporaryRedirectToNewPersonWhenUpstreamRedirectsToPersonMergedInto()
+      throws Exception {
+    apiClient = spy(apiClient);
+    doReturn(responseRedirectedToPerson(MERGED_INTO_IDENTIFIER))
+        .when(apiClient)
+        .fetchGetResult(any(URI.class));
+    handler = new FetchCristinPersonHandler(apiClient, environment);
+    var gatewayResponse = sendQuery(ZERO_QUERY_PARAMS, VALID_PATH_PARAM);
+
+    assertEquals(TEMPORARY_REDIRECT, gatewayResponse.getStatusCode());
+    assertThat(
+        gatewayResponse.getHeaders().get(HttpHeaders.LOCATION),
+        equalTo(EXPECTED_NVA_LOCATION_FOR_MERGED_PERSON));
+  }
+
+  @Test
+  void shouldReturnTemporaryRedirectToNewPersonWhenUpstreamRedirectsAndClientIsAuthorized()
+      throws Exception {
+    apiClient = spy(apiClient);
+    doReturn(responseRedirectedToPerson(MERGED_INTO_IDENTIFIER))
+        .when(apiClient)
+        .fetchGetResultWithAuthentication(any(URI.class));
+    handler = new FetchCristinPersonHandler(apiClient, environment);
+    var gatewayResponse = sendAuthorizedQuery(MANAGE_OWN_AFFILIATION);
+
+    assertEquals(TEMPORARY_REDIRECT, gatewayResponse.getStatusCode());
+    assertThat(
+        gatewayResponse.getHeaders().get(HttpHeaders.LOCATION),
+        equalTo(EXPECTED_NVA_LOCATION_FOR_MERGED_PERSON));
+  }
+
+  @Test
+  void shouldReturnPersonDataWhenLookingUpByOrcidEvenThoughUpstreamRedirectsToCristinIdentifier()
+      throws Exception {
+    apiClient = spy(apiClient);
+    doReturn(responseRedirectedToPerson(MERGED_INTO_IDENTIFIER))
+        .when(apiClient)
+        .fetchGetResult(any(URI.class));
+    handler = new FetchCristinPersonHandler(apiClient, environment);
+    var gatewayResponse = sendQuery(ZERO_QUERY_PARAMS, VALID_ORCID_PATH_PARAM);
+
+    assertEquals(HTTP_OK, gatewayResponse.getStatusCode());
+  }
+
+  private HttpResponseFaker responseRedirectedToPerson(String identifier) {
+    var cristinUriAfterRedirect =
+        fromUri(CRISTIN_API_URL).addChild(PERSONS_PATH).addChild(identifier).getUri();
+    return HttpResponseFaker.respondedFromUri(
+        readFromResources(CRISTIN_GET_PERSON_RESPONSE_JSON), cristinUriAfterRedirect);
   }
 
   private Optional<TypedValue> extractNinObjectFromIdentifiers(Person responseBody) {

--- a/cristin-person/src/test/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandlerTest.java
+++ b/cristin-person/src/test/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandlerTest.java
@@ -10,13 +10,11 @@ import static no.unit.nva.cristin.model.Constants.BASE_PATH;
 import static no.unit.nva.cristin.model.Constants.CRISTIN_API_URL;
 import static no.unit.nva.cristin.model.Constants.DOMAIN_NAME;
 import static no.unit.nva.cristin.model.Constants.OBJECT_MAPPER;
-import static no.unit.nva.cristin.model.Constants.PERSONS_PATH;
 import static no.unit.nva.cristin.model.JsonPropertyNames.ID;
 import static no.unit.nva.cristin.person.model.nva.JsonPropertyNames.NATIONAL_IDENTITY_NUMBER;
 import static no.unit.nva.exception.TemporaryRedirectException.TEMPORARY_REDIRECT;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
-import static no.unit.nva.utils.UriUtils.getCristinUri;
 import static nva.commons.apigateway.AccessRight.MANAGE_CUSTOMERS;
 import static nva.commons.apigateway.AccessRight.MANAGE_OWN_AFFILIATION;
 import static nva.commons.apigateway.MediaTypes.APPLICATION_PROBLEM_JSON;
@@ -80,11 +78,11 @@ public class FetchCristinPersonHandlerTest {
   private static final String NVA_API_GET_PERSON_RESPONSE_JSON = "nvaApiGetPersonResponse.json";
   private static final Map<String, String> ILLEGAL_PATH_PARAM = Map.of(ID, "string");
   private static final Map<String, String> ILLEGAL_QUERY_PARAMS = Map.of("somekey", "somevalue");
-  private static final Map<String, String> VALID_PATH_PARAM = Map.of(ID, "12345");
+  private static final Map<String, String> VALID_PATH_PARAM = Map.of(ID, "359084");
   private static final Map<String, String> ZERO_QUERY_PARAMS = Collections.emptyMap();
   private static final String EMPTY_STRING = "";
   private static final String EXPECTED_CRISTIN_URI_WITH_IDENTIFIER =
-      "https://api.cristin-test.uio.no/v2/persons/12345";
+      "https://api.cristin-test.uio.no/v2/persons/359084";
   private static final Map<String, String> VALID_ORCID_PATH_PARAM =
       Map.of(ID, "1234-1234-1234-1234");
   private static final String EXPECTED_CRISTIN_URI_WITH_ORCID_IDENTIFIER =
@@ -100,11 +98,9 @@ public class FetchCristinPersonHandlerTest {
   private static final String MERGED_INTO_IDENTIFIER = "5647";
   private static final String EXPECTED_NVA_LOCATION_FOR_MERGED_PERSON =
       "https://%s/%s/person/%s".formatted(DOMAIN_NAME, BASE_PATH, MERGED_INTO_IDENTIFIER);
-  private static final String CRISTIN_URI_WITHOUT_PATH = "https://www.cristin.no";
-  private static final String INSTITUTIONS_PATH = "institutions";
-  private static final String PERSONS_PATH_CAPITALIZED = "Persons";
-  private static final String SLASH = "/";
-  private static final Map<String, String> PATH_PARAM_WITH_LEADING_ZEROS = Map.of(ID, "0012345");
+  private static final Map<String, String> PATH_PARAM_WITH_LEADING_ZEROS = Map.of(ID, "0359084");
+  private static final String EXPECTED_NVA_LOCATION_FOR_CANONICAL_PERSON =
+      "https://%s/%s/person/%s".formatted(DOMAIN_NAME, BASE_PATH, VALID_PATH_PARAM.get(ID));
 
   private CristinPersonApiClient apiClient;
   private final Environment environment = new Environment();
@@ -319,7 +315,7 @@ public class FetchCristinPersonHandlerTest {
     var captor = ArgumentCaptor.forClass(HttpRequest.class);
     verify(mockHttpClient).send(captor.capture(), any());
 
-    var expected = "https://api.cristin-test.uio.no/v2/persons/12345?lang=en%2Cnb%2Cnn";
+    var expected = "https://api.cristin-test.uio.no/v2/persons/359084?lang=en%2Cnb%2Cnn";
     var actual = captor.getValue().uri().toString();
 
     assertThat(actual, equalTo(expected));
@@ -375,7 +371,7 @@ public class FetchCristinPersonHandlerTest {
   void shouldReturnTemporaryRedirectToNewPersonWhenUpstreamRedirectsToPersonMergedInto()
       throws Exception {
     apiClient = spy(apiClient);
-    doReturn(responseRedirectedToPerson(MERGED_INTO_IDENTIFIER))
+    doReturn(new HttpResponseFaker(cristinPersonWithIdentifier(MERGED_INTO_IDENTIFIER)))
         .when(apiClient)
         .fetchGetResult(any(URI.class));
     handler = new FetchCristinPersonHandler(apiClient, environment);
@@ -391,7 +387,7 @@ public class FetchCristinPersonHandlerTest {
   void shouldReturnTemporaryRedirectToNewPersonWhenUpstreamRedirectsAndClientIsAuthorized()
       throws Exception {
     apiClient = spy(apiClient);
-    doReturn(responseRedirectedToPerson(MERGED_INTO_IDENTIFIER))
+    doReturn(new HttpResponseFaker(cristinPersonWithIdentifier(MERGED_INTO_IDENTIFIER)))
         .when(apiClient)
         .fetchGetResultWithAuthentication(any(URI.class));
     handler = new FetchCristinPersonHandler(apiClient, environment);
@@ -407,7 +403,7 @@ public class FetchCristinPersonHandlerTest {
   void shouldReturnPersonDataWhenLookingUpByOrcidEvenThoughUpstreamRedirectsToCristinIdentifier()
       throws Exception {
     apiClient = spy(apiClient);
-    doReturn(responseRedirectedToPerson(MERGED_INTO_IDENTIFIER))
+    doReturn(new HttpResponseFaker(cristinPersonWithIdentifier(MERGED_INTO_IDENTIFIER)))
         .when(apiClient)
         .fetchGetResult(any(URI.class));
     handler = new FetchCristinPersonHandler(apiClient, environment);
@@ -417,26 +413,10 @@ public class FetchCristinPersonHandlerTest {
   }
 
   @Test
-  void shouldReturnNotFoundWhenUpstreamRedirectsToPersonThatDoesNotExist() throws Exception {
-    apiClient = spy(apiClient);
-    doReturn(
-            HttpResponseFaker.respondedFromUri(
-                EMPTY_STRING,
-                HttpURLConnection.HTTP_NOT_FOUND,
-                cristinUriForPerson(MERGED_INTO_IDENTIFIER)))
-        .when(apiClient)
-        .fetchGetResult(any(URI.class));
-    handler = new FetchCristinPersonHandler(apiClient, environment);
-    var gatewayResponse = sendQuery(ZERO_QUERY_PARAMS, VALID_PATH_PARAM);
-
-    assertEquals(HttpURLConnection.HTTP_NOT_FOUND, gatewayResponse.getStatusCode());
-  }
-
-  @Test
   void shouldNotLogStackTraceWhenPersonIsMergedIntoAnother() throws Exception {
     final var logRecorder = LogRecorder.forRoot(FetchCristinPersonHandler.class);
     apiClient = spy(apiClient);
-    doReturn(responseRedirectedToPerson(MERGED_INTO_IDENTIFIER))
+    doReturn(new HttpResponseFaker(cristinPersonWithIdentifier(MERGED_INTO_IDENTIFIER)))
         .when(apiClient)
         .fetchGetResult(any(URI.class));
     handler = new FetchCristinPersonHandler(apiClient, environment);
@@ -450,91 +430,26 @@ public class FetchCristinPersonHandlerTest {
   }
 
   @Test
-  void shouldNotRedirectWhenUpstreamIdentifierIsNumericallyEqualButWrittenDifferently()
-      throws Exception {
-    apiClient = spy(apiClient);
-    doReturn(responseRedirectedToPerson(VALID_PATH_PARAM.get(ID)))
-        .when(apiClient)
-        .fetchGetResult(any(URI.class));
-    handler = new FetchCristinPersonHandler(apiClient, environment);
+  void shouldRedirectToCanonicalPersonWhenRequestedIdentifierIsZeroPadded() throws Exception {
     var gatewayResponse = sendQuery(ZERO_QUERY_PARAMS, PATH_PARAM_WITH_LEADING_ZEROS);
 
-    assertEquals(HTTP_OK, gatewayResponse.getStatusCode());
-  }
-
-  @Test
-  void shouldRedirectWhenUpstreamPersonUriHasTrailingSlash() throws Exception {
-    apiClient = spy(apiClient);
-    doReturn(
-            HttpResponseFaker.respondedFromUri(
-                readFromResources(CRISTIN_GET_PERSON_RESPONSE_JSON),
-                URI.create(cristinUriForPerson(MERGED_INTO_IDENTIFIER) + SLASH)))
-        .when(apiClient)
-        .fetchGetResult(any(URI.class));
-    handler = new FetchCristinPersonHandler(apiClient, environment);
-    var gatewayResponse = sendQuery(ZERO_QUERY_PARAMS, VALID_PATH_PARAM);
-
     assertEquals(TEMPORARY_REDIRECT, gatewayResponse.getStatusCode());
     assertThat(
         gatewayResponse.getHeaders().get(HttpHeaders.LOCATION),
-        equalTo(EXPECTED_NVA_LOCATION_FOR_MERGED_PERSON));
+        equalTo(EXPECTED_NVA_LOCATION_FOR_CANONICAL_PERSON));
   }
 
   @Test
-  void shouldRedirectWhenUpstreamPersonPathIsSpelledWithDifferentCasing() throws Exception {
-    apiClient = spy(apiClient);
-    doReturn(
-            HttpResponseFaker.respondedFromUri(
-                readFromResources(CRISTIN_GET_PERSON_RESPONSE_JSON),
-                getCristinUri(MERGED_INTO_IDENTIFIER, PERSONS_PATH_CAPITALIZED)))
-        .when(apiClient)
-        .fetchGetResult(any(URI.class));
-    handler = new FetchCristinPersonHandler(apiClient, environment);
-    var gatewayResponse = sendQuery(ZERO_QUERY_PARAMS, VALID_PATH_PARAM);
-
-    assertEquals(TEMPORARY_REDIRECT, gatewayResponse.getStatusCode());
-    assertThat(
-        gatewayResponse.getHeaders().get(HttpHeaders.LOCATION),
-        equalTo(EXPECTED_NVA_LOCATION_FOR_MERGED_PERSON));
-  }
-
-  @Test
-  void shouldNotRedirectWhenUpstreamRespondsFromResourceThatIsNotAPerson() throws Exception {
-    apiClient = spy(apiClient);
-    doReturn(
-            HttpResponseFaker.respondedFromUri(
-                readFromResources(CRISTIN_GET_PERSON_RESPONSE_JSON),
-                getCristinUri(MERGED_INTO_IDENTIFIER, INSTITUTIONS_PATH)))
-        .when(apiClient)
-        .fetchGetResult(any(URI.class));
-    handler = new FetchCristinPersonHandler(apiClient, environment);
+  void shouldNotRedirectWhenRequestedIdentifierIsAlreadyCanonical() throws Exception {
     var gatewayResponse = sendQuery(ZERO_QUERY_PARAMS, VALID_PATH_PARAM);
 
     assertEquals(HTTP_OK, gatewayResponse.getStatusCode());
   }
 
-  @Test
-  void shouldReturnPersonWhenUpstreamRespondsFromUriWithoutAnyPath() throws Exception {
-    apiClient = spy(apiClient);
-    doReturn(
-            HttpResponseFaker.respondedFromUri(
-                readFromResources(CRISTIN_GET_PERSON_RESPONSE_JSON),
-                URI.create(CRISTIN_URI_WITHOUT_PATH)))
-        .when(apiClient)
-        .fetchGetResult(any(URI.class));
-    handler = new FetchCristinPersonHandler(apiClient, environment);
-    var gatewayResponse = sendQuery(ZERO_QUERY_PARAMS, VALID_PATH_PARAM);
-
-    assertEquals(HTTP_OK, gatewayResponse.getStatusCode());
-  }
-
-  private HttpResponseFaker responseRedirectedToPerson(String identifier) {
-    return HttpResponseFaker.respondedFromUri(
-        readFromResources(CRISTIN_GET_PERSON_RESPONSE_JSON), cristinUriForPerson(identifier));
-  }
-
-  private URI cristinUriForPerson(String identifier) {
-    return getCristinUri(identifier, PERSONS_PATH);
+  private String cristinPersonWithIdentifier(String identifier) {
+    var cristinPerson = randomCristinPerson();
+    cristinPerson.setCristinPersonId(identifier);
+    return cristinPerson.toString();
   }
 
   private Optional<TypedValue> extractNinObjectFromIdentifiers(Person responseBody) {

--- a/cristin-person/src/test/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandlerTest.java
+++ b/cristin-person/src/test/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandlerTest.java
@@ -405,11 +405,29 @@ public class FetchCristinPersonHandlerTest {
     assertEquals(HTTP_OK, gatewayResponse.getStatusCode());
   }
 
+  @Test
+  void shouldReturnNotFoundWhenUpstreamRedirectsToPersonThatDoesNotExist() throws Exception {
+    apiClient = spy(apiClient);
+    doReturn(
+            HttpResponseFaker.respondedFromUri(
+                EMPTY_STRING,
+                HttpURLConnection.HTTP_NOT_FOUND,
+                cristinUriForPerson(MERGED_INTO_IDENTIFIER)))
+        .when(apiClient)
+        .fetchGetResult(any(URI.class));
+    handler = new FetchCristinPersonHandler(apiClient, environment);
+    var gatewayResponse = sendQuery(ZERO_QUERY_PARAMS, VALID_PATH_PARAM);
+
+    assertEquals(HttpURLConnection.HTTP_NOT_FOUND, gatewayResponse.getStatusCode());
+  }
+
   private HttpResponseFaker responseRedirectedToPerson(String identifier) {
-    var cristinUriAfterRedirect =
-        fromUri(CRISTIN_API_URL).addChild(PERSONS_PATH).addChild(identifier).getUri();
     return HttpResponseFaker.respondedFromUri(
-        readFromResources(CRISTIN_GET_PERSON_RESPONSE_JSON), cristinUriAfterRedirect);
+        readFromResources(CRISTIN_GET_PERSON_RESPONSE_JSON), cristinUriForPerson(identifier));
+  }
+
+  private URI cristinUriForPerson(String identifier) {
+    return fromUri(CRISTIN_API_URL).addChild(PERSONS_PATH).addChild(identifier).getUri();
   }
 
   private Optional<TypedValue> extractNinObjectFromIdentifiers(Person responseBody) {

--- a/cristin-person/src/test/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandlerTest.java
+++ b/cristin-person/src/test/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandlerTest.java
@@ -6,13 +6,17 @@ import static no.unit.nva.cristin.common.ErrorMessages.ERROR_MESSAGE_BACKEND_FET
 import static no.unit.nva.cristin.common.ErrorMessages.ERROR_MESSAGE_INVALID_PATH_PARAMETER_FOR_PERSON_ID;
 import static no.unit.nva.cristin.common.ErrorMessages.ERROR_MESSAGE_INVALID_QUERY_PARAMETER_ON_PERSON_LOOKUP;
 import static no.unit.nva.cristin.common.ErrorMessages.ERROR_MESSAGE_SERVER_ERROR;
+import static no.unit.nva.cristin.model.Constants.BASE_PATH;
 import static no.unit.nva.cristin.model.Constants.CRISTIN_API_URL;
+import static no.unit.nva.cristin.model.Constants.DOMAIN_NAME;
 import static no.unit.nva.cristin.model.Constants.OBJECT_MAPPER;
+import static no.unit.nva.cristin.model.Constants.PERSONS_PATH;
 import static no.unit.nva.cristin.model.JsonPropertyNames.ID;
 import static no.unit.nva.cristin.person.model.nva.JsonPropertyNames.NATIONAL_IDENTITY_NUMBER;
 import static no.unit.nva.exception.TemporaryRedirectException.TEMPORARY_REDIRECT;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+import static no.unit.nva.utils.UriUtils.getCristinUri;
 import static nva.commons.apigateway.AccessRight.MANAGE_CUSTOMERS;
 import static nva.commons.apigateway.AccessRight.MANAGE_OWN_AFFILIATION;
 import static nva.commons.apigateway.MediaTypes.APPLICATION_PROBLEM_JSON;
@@ -95,8 +99,7 @@ public class FetchCristinPersonHandlerTest {
       "nvaApiGetPersonNviVerified.json";
   private static final String MERGED_INTO_IDENTIFIER = "5647";
   private static final String EXPECTED_NVA_LOCATION_FOR_MERGED_PERSON =
-      "https://api.dev.nva.aws.unit.no/cristin/person/5647";
-  private static final String PERSONS_PATH = "persons";
+      "https://%s/%s/person/%s".formatted(DOMAIN_NAME, BASE_PATH, MERGED_INTO_IDENTIFIER);
   private static final String CRISTIN_URI_WITHOUT_PATH = "https://www.cristin.no";
   private static final Map<String, String> PATH_PARAM_WITH_LEADING_ZEROS = Map.of(ID, "0012345");
 
@@ -475,7 +478,7 @@ public class FetchCristinPersonHandlerTest {
   }
 
   private URI cristinUriForPerson(String identifier) {
-    return fromUri(CRISTIN_API_URL).addChild(PERSONS_PATH).addChild(identifier).getUri();
+    return getCristinUri(identifier, PERSONS_PATH);
   }
 
   private Optional<TypedValue> extractNinObjectFromIdentifiers(Person responseBody) {

--- a/cristin-person/src/test/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandlerTest.java
+++ b/cristin-person/src/test/java/no/unit/nva/cristin/person/fetch/FetchCristinPersonHandlerTest.java
@@ -52,13 +52,16 @@ import no.unit.nva.cristin.person.model.cristin.CristinPersonEmployment;
 import no.unit.nva.cristin.person.model.nva.Person;
 import no.unit.nva.cristin.person.model.nva.TypedValue;
 import no.unit.nva.cristin.testing.HttpResponseFaker;
+import no.unit.nva.exception.TemporaryRedirectException;
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.GatewayResponse;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.core.Environment;
 import nva.commons.core.ioutils.IoUtils;
+import nva.commons.logutils.LogRecorder;
 import org.apache.hc.core5.http.HttpHeaders;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -421,6 +424,21 @@ public class FetchCristinPersonHandlerTest {
     var gatewayResponse = sendQuery(ZERO_QUERY_PARAMS, VALID_PATH_PARAM);
 
     assertEquals(HttpURLConnection.HTTP_NOT_FOUND, gatewayResponse.getStatusCode());
+  }
+
+  @Test
+  void shouldNotLogStackTraceWhenPersonIsMergedIntoAnother() throws Exception {
+    final var logRecorder = LogRecorder.forRoot(FetchCristinPersonHandler.class);
+    apiClient = spy(apiClient);
+    doReturn(responseRedirectedToPerson(MERGED_INTO_IDENTIFIER))
+        .when(apiClient)
+        .fetchGetResult(any(URI.class));
+    handler = new FetchCristinPersonHandler(apiClient, environment);
+    var gatewayResponse = sendQuery(ZERO_QUERY_PARAMS, VALID_PATH_PARAM);
+
+    assertEquals(TEMPORARY_REDIRECT, gatewayResponse.getStatusCode());
+    Assertions.assertThat(logRecorder.messages())
+        .noneMatch(message -> message.contains(TemporaryRedirectException.class.getName()));
   }
 
   @Test

--- a/cristin-testing/src/main/java/no/unit/nva/cristin/testing/HttpResponseFaker.java
+++ b/cristin-testing/src/main/java/no/unit/nva/cristin/testing/HttpResponseFaker.java
@@ -27,7 +27,6 @@ public class HttpResponseFaker implements HttpResponse<String> {
   private final transient String bodyString;
   private final transient int status;
   private final transient HttpHeaders httpHeaders;
-  private final transient URI effectiveUri;
 
   public HttpResponseFaker(String bodyString) {
     this(bodyString, HTTP_OK);
@@ -37,34 +36,17 @@ public class HttpResponseFaker implements HttpResponse<String> {
     this(bodyString, status, defaultHeaders());
   }
 
-  public HttpResponseFaker(String bodyString, int status, HttpHeaders httpHeaders) {
-    this(bodyString, status, httpHeaders, null);
-  }
-
   /**
    * Main constructor for a stub of HttpResponse.
    *
    * @param bodyString Body content of HttpResponse
    * @param status Http status code of HttpResponse
    * @param httpHeaders HttpHeaders used in the HttpResponse
-   * @param effectiveUri the URI of the final request, which differs from the requested URI when
-   *     redirects have been followed
    */
-  public HttpResponseFaker(
-      String bodyString, int status, HttpHeaders httpHeaders, URI effectiveUri) {
+  public HttpResponseFaker(String bodyString, int status, HttpHeaders httpHeaders) {
     this.bodyString = bodyString;
     this.status = status;
     this.httpHeaders = httpHeaders;
-    this.effectiveUri = effectiveUri;
-  }
-
-  public static HttpResponseFaker respondedFromUri(String bodyString, URI effectiveUri) {
-    return respondedFromUri(bodyString, HTTP_OK, effectiveUri);
-  }
-
-  public static HttpResponseFaker respondedFromUri(
-      String bodyString, int status, URI effectiveUri) {
-    return new HttpResponseFaker(bodyString, status, defaultHeaders(), effectiveUri);
   }
 
   /**
@@ -120,7 +102,7 @@ public class HttpResponseFaker implements HttpResponse<String> {
 
   @Override
   public URI uri() {
-    return effectiveUri;
+    return null;
   }
 
   @Override

--- a/cristin-testing/src/main/java/no/unit/nva/cristin/testing/HttpResponseFaker.java
+++ b/cristin-testing/src/main/java/no/unit/nva/cristin/testing/HttpResponseFaker.java
@@ -26,6 +26,7 @@ public class HttpResponseFaker implements HttpResponse<String> {
   private final transient String bodyString;
   private final transient int status;
   private final transient HttpHeaders httpHeaders;
+  private final transient URI effectiveUri;
 
   public HttpResponseFaker(String bodyString) {
     this(bodyString, 200);
@@ -35,17 +36,29 @@ public class HttpResponseFaker implements HttpResponse<String> {
     this(bodyString, status, defaultHeaders());
   }
 
+  public HttpResponseFaker(String bodyString, int status, HttpHeaders httpHeaders) {
+    this(bodyString, status, httpHeaders, null);
+  }
+
   /**
    * Main constructor for a stub of HttpResponse.
    *
    * @param bodyString Body content of HttpResponse
    * @param status Http status code of HttpResponse
    * @param httpHeaders HttpHeaders used in the HttpResponse
+   * @param effectiveUri the URI of the final request, which differs from the requested URI when
+   *     redirects have been followed
    */
-  public HttpResponseFaker(String bodyString, int status, HttpHeaders httpHeaders) {
+  public HttpResponseFaker(
+      String bodyString, int status, HttpHeaders httpHeaders, URI effectiveUri) {
     this.bodyString = bodyString;
     this.status = status;
     this.httpHeaders = httpHeaders;
+    this.effectiveUri = effectiveUri;
+  }
+
+  public static HttpResponseFaker respondedFromUri(String bodyString, URI effectiveUri) {
+    return new HttpResponseFaker(bodyString, 200, defaultHeaders(), effectiveUri);
   }
 
   /**
@@ -101,7 +114,7 @@ public class HttpResponseFaker implements HttpResponse<String> {
 
   @Override
   public URI uri() {
-    return null;
+    return effectiveUri;
   }
 
   @Override

--- a/cristin-testing/src/main/java/no/unit/nva/cristin/testing/HttpResponseFaker.java
+++ b/cristin-testing/src/main/java/no/unit/nva/cristin/testing/HttpResponseFaker.java
@@ -1,5 +1,6 @@
 package no.unit.nva.cristin.testing;
 
+import static java.net.HttpURLConnection.HTTP_OK;
 import static no.unit.nva.cristin.model.Constants.LINK;
 import static no.unit.nva.cristin.model.Constants.REL_NEXT;
 import static no.unit.nva.cristin.model.Constants.REL_PREV;
@@ -29,7 +30,7 @@ public class HttpResponseFaker implements HttpResponse<String> {
   private final transient URI effectiveUri;
 
   public HttpResponseFaker(String bodyString) {
-    this(bodyString, 200);
+    this(bodyString, HTTP_OK);
   }
 
   public HttpResponseFaker(String bodyString, int status) {
@@ -58,7 +59,12 @@ public class HttpResponseFaker implements HttpResponse<String> {
   }
 
   public static HttpResponseFaker respondedFromUri(String bodyString, URI effectiveUri) {
-    return new HttpResponseFaker(bodyString, 200, defaultHeaders(), effectiveUri);
+    return respondedFromUri(bodyString, HTTP_OK, effectiveUri);
+  }
+
+  public static HttpResponseFaker respondedFromUri(
+      String bodyString, int status, URI effectiveUri) {
+    return new HttpResponseFaker(bodyString, status, defaultHeaders(), effectiveUri);
   }
 
   /**

--- a/docs/cristin-proxy-swagger.yaml
+++ b/docs/cristin-proxy-swagger.yaml
@@ -1413,6 +1413,8 @@ paths:
               examples:
                 objectExample:
                   $ref: "#/components/examples/PersonExample"
+        "307":
+          $ref: "#/components/responses/307"
         "400":
           $ref: "#/components/responses/400"
         "401":

--- a/docs/cristin-proxy-swagger.yaml
+++ b/docs/cristin-proxy-swagger.yaml
@@ -2389,6 +2389,17 @@ paths:
 
 components:
   responses:
+    "307":
+      description: >-
+        Temporary Redirect. The requested person has been merged into another person and
+        the Location header points to the person to use instead
+      headers:
+        Location:
+          description: Uri of the person the requested person has been merged into
+          schema:
+            type: string
+            format: uri
+          example: "https://api.nva.unit.no/cristin/person/5647"
     "400":
       description: Bad Request
       content:

--- a/docs/cristin-proxy-swagger.yaml
+++ b/docs/cristin-proxy-swagger.yaml
@@ -1414,7 +1414,16 @@ paths:
                 objectExample:
                   $ref: "#/components/examples/PersonExample"
         "307":
-          $ref: "#/components/responses/307"
+          description: >-
+            Temporary Redirect. The requested person has been merged into another person and
+            the Location header points to the person to use instead
+          headers:
+            Location:
+              description: Uri of the person the requested person has been merged into
+              schema:
+                type: string
+                format: uri
+              example: "https://api.nva.unit.no/cristin/person/5647"
         "400":
           $ref: "#/components/responses/400"
         "401":
@@ -2391,17 +2400,6 @@ paths:
 
 components:
   responses:
-    "307":
-      description: >-
-        Temporary Redirect. The requested person has been merged into another person and
-        the Location header points to the person to use instead
-      headers:
-        Location:
-          description: Uri of the person the requested person has been merged into
-          schema:
-            type: string
-            format: uri
-          example: "https://api.nva.unit.no/cristin/person/5647"
     "400":
       description: Bad Request
       content:


### PR DESCRIPTION
Cristin answers `307` with a relative location when a person has been merged into another one. The JDK client follows redirects, so `GET /cristin/person/211415` returned person `5647` as `200 OK` under the wrong URI. The person endpoint now redirects to the canonical person instead.

```
GET /cristin/person/211415   → 307, Location: .../cristin/person/5647
GET /cristin/person/0359084  → 307, Location: .../cristin/person/359084
GET /cristin/person/{orcid}  → 200 + person data
```

- Compare the requested identifier against `cristin_person_id` in the response body, which is Cristin's own answer to which person this is. That covers both a merged identifier and a non-canonical spelling of the same one, for the authorized and the unauthorized fetch alike
- Add `TemporaryRedirectException`, a concrete `RedirectException`, which `ApiGatewayHandler` turns into a `307` with a `Location` header pointing at the NVA person URI
- Answer `200` for ORCID lookups. Cristin implements those as a `307` as well (`/v2/persons/ORCID:0000-0003-0013-2874 → 307, location: 5647`), but an ORCID is a different kind of key rather than a non-canonical spelling of a Cristin identifier
- Log the redirect without the stack trace `RestRequestHandler` would otherwise emit as a `WARN` on every merged-person lookup
- Document the `307` and its `Location` header on `GetPersonById` in the OpenAPI spec

**Before merging:** `scopus-import` in `nva-publication-api` builds its `HttpClient` without `followRedirects` and turns any non-200 into `Optional.empty()` (`CristinConnection:52,133`), so a merged person silently loses its Cristin enrichment. The ORCID fallback in `CristinPersonRetriever` covers contributors that have an ORCID, but not the rest. That client needs `followRedirects(Redirect.ALWAYS)` deployed first.

Query and search are untouched, so enrichment there still follows redirects silently. Cristin's search does not normally return merged persons.

https://sikt.atlassian.net/browse/NP-51564
